### PR TITLE
Python 3 compatibility support.

### DIFF
--- a/hydra_base/__init__.py
+++ b/hydra_base/__init__.py
@@ -18,6 +18,9 @@
 #
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 import logging
 from . import config

--- a/hydra_base/config.py
+++ b/hydra_base/config.py
@@ -16,6 +16,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
+
 import os
 import glob
 import sys

--- a/hydra_base/exceptions.py
+++ b/hydra_base/exceptions.py
@@ -16,6 +16,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
+
 
 class HydraError(Exception):
     def __init__(self, message="A hydra error has occurred", code=0000):

--- a/hydra_base/hydra_logging.py
+++ b/hydra_base/hydra_logging.py
@@ -19,7 +19,7 @@
 
 import logging
 import logging.config
-import config
+from . import config
 import os
 import ctypes
 import inspect

--- a/hydra_base/lib/attributes.py
+++ b/hydra_base/lib/attributes.py
@@ -16,6 +16,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
+
 
 import logging
 log = logging.getLogger(__name__)

--- a/hydra_base/lib/data.py
+++ b/hydra_base/lib/data.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 import datetime
 import sys

--- a/hydra_base/lib/groups.py
+++ b/hydra_base/lib/groups.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 from ..exceptions import HydraError, ResourceNotFoundError
 from . import scenario

--- a/hydra_base/lib/network.py
+++ b/hydra_base/lib/network.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 import datetime
 import time
@@ -855,9 +858,9 @@ def _get_metadata(network_id, user_id):
     metadata_dict = dict()
     for m in all_metadata:
         if metadata_dict.get(m.dataset_id):
-            metadata_dict[m.dataset_id][m.metadata_name] = unicode(m.metadata_val)
+            metadata_dict[m.dataset_id][m.metadata_name] = str(m.metadata_val)
         else:
-            metadata_dict[m.dataset_id] = {m.metadata_name : unicode(m.metadata_val)}
+            metadata_dict[m.dataset_id] = {m.metadata_name: str(m.metadata_val)}
 
     logging.info("metadata processed in %s", time.time()-x)
 

--- a/hydra_base/lib/notes.py
+++ b/hydra_base/lib/notes.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 from ..db.model import Note
 from .. import db

--- a/hydra_base/lib/objects.py
+++ b/hydra_base/lib/objects.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 import json
 
@@ -30,6 +33,7 @@ from .. import config
 import zlib
 import pandas as pd
 
+
 class JSONObject(dict):
     """
         A dictionary object whose attributes can be accesed via a '.'.
@@ -37,7 +41,7 @@ class JSONObject(dict):
     """
     def __init__(self, obj_dict={}, parent=None):
 
-        if isinstance(obj_dict, str) or isinstance(obj_dict, unicode):
+        if isinstance(obj_dict, str):
             try:
                 obj = json.loads(obj_dict)
                 assert isinstance(obj, dict), "JSON string does not evaluate to a dict"
@@ -125,7 +129,7 @@ class JSONObject(dict):
                         v = {}
 
                 if isinstance(v, datetime):
-                    v = unicode(v)
+                    v = str(v)
 
                 #Put in 'id' where a DB table has mytable_id, for example
                 #Turn something like 'tProject.project_id' into 'tProject.id'
@@ -162,7 +166,7 @@ class JSONObject(dict):
                         if k == 'resource_attr_id':
                             setattr(self, 'id', v) 
 
-                setattr(self, unicode(k), v)
+                setattr(self, str(k), v)
 
     def __getattr__(self, name):
         # Make sure that "special" methods are returned as before.
@@ -190,7 +194,7 @@ class JSONObject(dict):
     #Only for type attrs. How best to generalise this?
     def get_properties(self):
         if self.get('properties') and self.get('properties') is not None:
-            return unicode(self.properties)
+            return str(self.properties)
         else:
             return None
 
@@ -246,7 +250,7 @@ class Dataset(JSONObject):
                 log.warn("Cannot parse dataset. No value specified.")
                 return None
 
-            data = unicode(self.value)
+            data = str(self.value)
 
             if data.upper().strip() == 'NULL':
                 return 'NULL'
@@ -318,13 +322,13 @@ class Dataset(JSONObject):
         #want to enforce this rigidly
         metadata_keys = [m.lower() for m in metadata_dict]
         if user_id is not None and 'user_id' not in metadata_keys:
-            metadata_dict['user_id'] = unicode(user_id)
+            metadata_dict['user_id'] = str(user_id)
 
         if source is not None and 'source' not in metadata_keys:
-            metadata_dict['source'] = unicode(source)
+            metadata_dict['source'] = str(source)
 
         for k, v in metadata_dict.items():
-            metadata_dict[k] = unicode(v)
+            metadata_dict[k] = str(v)
 
         return metadata_dict
 

--- a/hydra_base/lib/plugins.py
+++ b/hydra_base/lib/plugins.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 from ..import config
 

--- a/hydra_base/lib/project.py
+++ b/hydra_base/lib/project.py
@@ -16,6 +16,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
+
 
 from ..exceptions import ResourceNotFoundError
 from . import scenario

--- a/hydra_base/lib/rules.py
+++ b/hydra_base/lib/rules.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 from ..db.model import Rule
 from .. import db

--- a/hydra_base/lib/scenario.py
+++ b/hydra_base/lib/scenario.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 import logging
 from ..exceptions import HydraError, PermissionError, ResourceNotFoundError

--- a/hydra_base/lib/sharing.py
+++ b/hydra_base/lib/sharing.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 from ..exceptions import HydraError, ResourceNotFoundError
 import logging

--- a/hydra_base/lib/static.py
+++ b/hydra_base/lib/static.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 import os
 from ..exceptions import HydraError

--- a/hydra_base/lib/template.py
+++ b/hydra_base/lib/template.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 from .. import db
 from ..db.model import Template, TemplateType, TypeAttr, Attr, Network, Node, Link, ResourceGroup, ResourceType, ResourceAttr, ResourceScenario, Scenario
@@ -1890,7 +1893,7 @@ def get_network_as_xml_template(network_id,**kwargs):
     for node_i in net_i.nodes:
         node_attributes = node_i.attributes
         attr_ids = [attr.attr_id for attr in node_attributes]
-        if attr_ids>0 and attr_ids not in existing_types['NODE']:
+        if len(attr_ids) > 0 and attr_ids not in existing_types['NODE']:
 
             node_resource    = etree.Element("resource")
 
@@ -1914,7 +1917,7 @@ def get_network_as_xml_template(network_id,**kwargs):
     for link_i in net_i.links:
         link_attributes = link_i.attributes
         attr_ids = [attr.attr_id for attr in link_attributes]
-        if attr_ids>0 and attr_ids not in existing_types['LINK']:
+        if len(attr_ids) > 0 and attr_ids not in existing_types['LINK']:
             link_resource    = etree.Element("resource")
 
             resource_type   = etree.SubElement(link_resource, "type")
@@ -1937,7 +1940,7 @@ def get_network_as_xml_template(network_id,**kwargs):
     for group_i in net_i.resourcegroups:
         group_attributes = group_i.attributes
         attr_ids = [attr.attr_id for attr in group_attributes]
-        if attr_ids>0 and attr_ids not in existing_types['GROUP']:
+        if len(attr_ids) > 0 and attr_ids not in existing_types['GROUP']:
             group_resource    = etree.Element("resource")
 
             resource_type   = etree.SubElement(group_resource, "type")
@@ -2010,12 +2013,12 @@ def get_etree_layout_as_dict(layout_tree):
     layout_dict = dict()
 
     for item in layout_tree.findall('item'):
-        name  = item.find('name').text
+        name = item.find('name').text
         val_element = item.find('value')
         value = val_element.text.strip()
         if value == '':
             children = val_element.getchildren()
-            value = etree.tostring(children[0], pretty_print=True)
+            value = etree.tostring(children[0], encoding="unicode", pretty_print=True)
         layout_dict[name] = value
     return layout_dict
 

--- a/hydra_base/lib/units.py
+++ b/hydra_base/lib/units.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 import os
 from copy import deepcopy

--- a/hydra_base/lib/users.py
+++ b/hydra_base/lib/users.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm.exc import NoResultFound

--- a/hydra_base/util/__init__.py
+++ b/hydra_base/util/__init__.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 import logging
 log = logging.getLogger(__name__)
@@ -230,7 +233,7 @@ def get_layout_as_string(layout):
     if isinstance(layout, dict):
         return json.dumps(layout)
 
-    if isinstance(layout, str) or isinstance(layout, unicode):
+    if isinstance(layout, str):
         try:
             return get_layout_as_string(json.loads(layout))
         except:
@@ -247,7 +250,7 @@ def get_layout_as_dict(layout):
     if isinstance(layout, dict):
         return layout
 
-    if isinstance(layout, str) or isinstance(layout, unicode):
+    if isinstance(layout, str):
         try:
             return get_layout_as_dict(json.loads(layout))
         except:

--- a/hydra_base/util/dataset_util.py
+++ b/hydra_base/util/dataset_util.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 import logging
 from decimal import Decimal
@@ -414,6 +417,7 @@ def validate_LESSTHAN(in_value, restriction):
                 subval = subval[1]
             validate_LESSTHAN(subval, restriction)
     else:
+        import pdb; pdb.set_trace()
         if value >= restriction:
             raise ValidationError("LESSTHAN: %s"%(restriction))
 

--- a/hydra_base/util/dataset_util.py
+++ b/hydra_base/util/dataset_util.py
@@ -417,7 +417,6 @@ def validate_LESSTHAN(in_value, restriction):
                 subval = subval[1]
             validate_LESSTHAN(subval, restriction)
     else:
-        import pdb; pdb.set_trace()
         if value >= restriction:
             raise ValidationError("LESSTHAN: %s"%(restriction))
 

--- a/hydra_base/util/hdb.py
+++ b/hydra_base/util/hdb.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 from ..db.model import Network, Scenario, Project, User, Role, Perm, RolePerm, RoleUser, ResourceAttr, ResourceType
 from sqlalchemy.orm.exc import NoResultFound

--- a/hydra_base/util/hydra_dateutil.py
+++ b/hydra_base/util/hydra_dateutil.py
@@ -15,6 +15,9 @@
 #
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 from datetime import datetime, timedelta
 import logging

--- a/hydra_base/util/permissions.py
+++ b/hydra_base/util/permissions.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 from .. import db
 from ..db.model import Perm, User, RolePerm, RoleUser

--- a/hydra_base/util/time_map.py
+++ b/hydra_base/util/time_map.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 time_map = {
     'picosecond'  : 'ps',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 import pytest
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,3 +1,7 @@
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
+
 from hydra_base.db import DeclarativeBase as _db
 from hydra_base.util.hdb import create_default_users_and_perms, make_root_user
 import hydra_base

--- a/tests/server.py
+++ b/tests/server.py
@@ -15,6 +15,10 @@
 #
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
+
 import logging
 from hydra_base import config
 import util

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -15,6 +15,10 @@
 #
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
+
 import hydra_base as hb
 from hydra_base.lib.objects import JSONObject, Dataset
 from hydra_base.exceptions import ResourceNotFoundError

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
 #
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
 
 from fixtures import *
 from lxml import etree

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,3 +1,7 @@
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
+
 import hydra_base
 import hydra_base.exceptions
 from hydra_base.lib.objects import JSONObject

--- a/tests/util.py
+++ b/tests/util.py
@@ -16,6 +16,10 @@
 #
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# Python 2 and 3 support
+from __future__ import unicode_literals
+from builtins import dict, str
+
 import logging
 
 import hydra_base
@@ -627,7 +631,7 @@ def check_network(request_net, response_net):
     for rs0 in s['resourcescenarios']:
         if rs0.value.type == 'timeseries':
             val = json.loads(rs0['value']['value'])
-            before_ts_times = val.values()[0].keys()
+            before_ts_times = list(val.values())[0].keys()
             before_times = []
             for t in before_ts_times:
                 try:
@@ -640,7 +644,7 @@ def check_network(request_net, response_net):
     for rs0 in s.resourcescenarios:
         if rs0.value.data_type == 'timeseries':
             val = json.loads(rs0.dataset.value)
-            after_ts_times = val.values()[0].keys()
+            after_ts_times = list(val.values())[0].keys()
             after_times = []
             for t in after_ts_times:
                 try:


### PR DESCRIPTION
I followed some advice on writing Python 2.7 and 3.x compatible code. This seemed to suggest using the following imports to make Python 2.7's strings and dictionaries behave like Python 3.x. Therefore I've added these imports to all the files. 

```python
from __future__ import unicode_literals
from builtins import dict, str
```
The PR also fixes a couple of residual errors with the changes to `dict` and conversion to unicode. Most of the tests now pass in Python 3. However #4 is not fixed by this PR and only affects Py3.