### PR TITLE
Data type meta class registry

### DIFF
--- a/hydra_base/lib/HydraTypes/Types.py
+++ b/hydra_base/lib/HydraTypes/Types.py
@@ -25,10 +25,15 @@ log = logging.getLogger(__name__)
 class DataTypeMeta(ABCMeta):
     def __new__(cls, clsname, bases, attrs):
         newclass = super(DataTypeMeta, cls).__new__(cls, clsname, bases, attrs)
+
         # Register class with hydra
         from .Registry import typemap
-        typemap[newclass.tag] = newclass
-        log.info('Registering data type "{}".'.format(newclass.tag))
+        if clsname != 'DataType':
+            if newclass.tag in typemap:
+                raise ValueError('Type with tag "{}" already registered.'.format(newclass.tag))
+            else:
+                typemap[newclass.tag] = newclass
+                log.info('Registering data type "{}".'.format(newclass.tag))
         return newclass
 
 
@@ -74,7 +79,6 @@ class DataType(object):
             the resulting instance
         """
         pass
-
 
 
 class Scalar(DataType):

--- a/hydra_base/lib/data.py
+++ b/hydra_base/lib/data.py
@@ -20,6 +20,7 @@
 import datetime
 import sys
 from ..util.hydra_dateutil import get_datetime
+from .HydraTypes.Registry import typemap
 import logging
 from ..db.model import Dataset, Metadata, DatasetOwner, DatasetCollection,\
         DatasetCollectionItem, ResourceScenario, ResourceAttr, TypeAttr
@@ -677,13 +678,12 @@ def _process_incoming_data(data, user_id=None, source=None):
 
     return datasets
 
+
 def _get_db_val(data_type, val):
-    if data_type in ('descriptor','scalar'):
-        return str(val)
-    elif data_type in ('timeseries', 'array', 'dataframe'):
-        return val
-    else:
-        raise HydraError("Invalid data type %s"%(data_type,))
+    data_klass = typemap[data_type.upper()]
+    data = data_klass(val)
+    return data.value
+
 
 def get_metadata(dataset_ids, **kwargs):
     return _get_metadata(dataset_ids)

--- a/hydra_base/lib/data.py
+++ b/hydra_base/lib/data.py
@@ -20,7 +20,6 @@
 import datetime
 import sys
 from ..util.hydra_dateutil import get_datetime
-from .HydraTypes.Registry import typemap
 import logging
 from ..db.model import Dataset, Metadata, DatasetOwner, DatasetCollection,\
         DatasetCollectionItem, ResourceScenario, ResourceAttr, TypeAttr
@@ -652,8 +651,7 @@ def _process_incoming_data(data, user_id=None, source=None):
             'created_by': user_id,
         }
 
-        db_val = _get_db_val(d.type, val)
-        data_dict['value'] = db_val
+        data_dict['value'] = val
 
         if d.metadata is not None:
             if isinstance(d.metadata, dict):
@@ -679,14 +677,9 @@ def _process_incoming_data(data, user_id=None, source=None):
     return datasets
 
 
-def _get_db_val(data_type, val):
-    data_klass = typemap[data_type.upper()]
-    data = data_klass(val)
-    return data.value
-
-
 def get_metadata(dataset_ids, **kwargs):
     return _get_metadata(dataset_ids)
+
 
 def _get_metadata(dataset_ids):
     """


### PR DESCRIPTION
A few more changes here. I screwed up the first commit (it should have been 2 separate ones).

- Don't register the base `DataType` class.
- Remove `_get_db_val`.