### PR TITLE
Make dataset api consistent

### DIFF
--- a/hydra_base/db/model.py
+++ b/hydra_base/db/model.py
@@ -208,6 +208,10 @@ class Dataset(Base, Inspect):
         """
             Check whether this user can read this dataset
         """
+        
+        #This user created the dataset
+        if int(self.created_by) == int(user_id):
+            return
 
         for owner in self.owners:
             if int(owner.user_id) == int(user_id):

--- a/hydra_base/lib/network.py
+++ b/hydra_base/lib/network.py
@@ -789,7 +789,7 @@ def _get_all_resourcescenarios(network_id, user_id):
                 ResourceScenario.source,
                 ResourceAttr.attr_id,
     ).outerjoin(DatasetOwner, and_(DatasetOwner.dataset_id==Dataset.id, DatasetOwner.user_id==user_id)).filter(
-                or_(Dataset.hidden=='N', DatasetOwner.user_id != None),
+                or_(and_(Dataset.hidden=='Y', Dataset.created_by==user_id), Dataset.hidden=='N', DatasetOwner.user_id != None), #If the dataset has the hidden flag set to true and user is not the creator of the datset, then they must be in the DatasetOwner
                 ResourceAttr.id == ResourceScenario.resource_attr_id,
                 Scenario.id==ResourceScenario.scenario_id,
                 Scenario.network_id==network_id,

--- a/hydra_base/lib/network.py
+++ b/hydra_base/lib/network.py
@@ -2480,7 +2480,7 @@ def clone_network(network_id, new_project=True, recipient_user_id=None, **kwargs
     if new_project == True:
         log.info("Creating a new project for cloned network")
         project = Project()
-        project.project_name="Proj"
+        project.name="Proj"
 
         project.set_owner(user_id)
         if recipient_user_id!=None:

--- a/hydra_base/lib/sharing.py
+++ b/hydra_base/lib/sharing.py
@@ -238,7 +238,7 @@ def set_network_permission(network_id, usernames, read, write, share,**kwargs):
         net_i.set_owner(user_i.id, read=read, write=write, share=share)
     db.DBSession.flush()
 
-def hide_dataset(dataset_id, exceptions, read, write, share,**kwargs):
+def hide_dataset(dataset_id, exceptions=[], read='Y', write='Y', share='Y',**kwargs):
     """
         Hide a particular piece of data so it can only be seen by its owner.
         Only an owner can hide (and unhide) data.

--- a/hydra_base/lib/template.py
+++ b/hydra_base/lib/template.py
@@ -1450,7 +1450,7 @@ def get_template_by_name(name,**kwargs):
         tmpl_i = db.DBSession.query(Template).filter(Template.name == name).options(joinedload_all('templatetypes.typeattrs.default_dataset.metadata')).one()
         return tmpl_i
     except NoResultFound:
-        log.info("%s is not a valid identifier for a template",name)
+        log.info("Template with name %s not found",name)
         raise HydraError('Template "%s" not found'%name)
 
 def add_templatetype(templatetype,**kwargs):

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -725,7 +725,7 @@ class TestScenario:
         log.info("Updating a shared dataset")
         ds = unlocked_resource_scenarios_value
 
-        updated_ds = JSONObject(hydra_base.update_dataset(ds.id, ds.name, ds.type, ds.value, ds.unit, ds.metadata, user_id=pytest.root_user_id))
+        updated_ds = JSONObject(hydra_base.update_dataset(ds, user_id=pytest.root_user_id))
 
         updated_unlocked_scenario = self.get_scenario(unlocked_scenario.id)
         #This should not have changed
@@ -889,7 +889,7 @@ class TestScenario:
 
         dataset.value = 'I am an updated test!'
 
-        new_ds = hydra_base.add_dataset(dataset.type, dataset.value, dataset.unit, {}, dataset.name, flush=True, user_id=pytest.root_user_id)
+        new_ds = hydra_base.add_dataset(dataset, flush=True, user_id=pytest.root_user_id)
 
         hydra_base.set_rs_dataset(resource_attr_id, source_scenario_id, new_ds.id, user_id=pytest.root_user_id)
 


### PR DESCRIPTION
I've made a few changes on this branch, primarily to do with making the add_dataset and update_dataset functions take Dataset objects instead of a list of parameters, making them more in line with other functions in the api.