### PR TITLE
Remove mysql password for running on travis.

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -26,7 +26,7 @@ def testdb_uri(db_backend):
         # This is designed to work on Travis CI
         return 'postgresql://postgres@localhost:5432/hydra_base_test'
     elif db_backend == 'mysql':
-        return 'mysql+mysqldb://root:root@localhost/hydra_base_test'
+        return 'mysql+mysqldb://root@localhost/hydra_base_test'
     else:
         raise ValueError('Database backend "{}" not supported when running the tests.'.format(db_backend))
 


### PR DESCRIPTION
The password must be blank for mysql on travis. Currently the `user:password` is hard coded in the fixtures. We could get this from an environment variable or try to detect travis?