### PR TITLE
Add a more efficienct parsing path for homogeneous dataframes.

### DIFF
--- a/hydra_base/lib/HydraTypes/Types.py
+++ b/hydra_base/lib/HydraTypes/Types.py
@@ -9,6 +9,7 @@
 import json
 import math
 import six
+import numpy as np
 import pandas as pd
 from abc import ABCMeta, abstractmethod, abstractproperty
 from datetime import datetime
@@ -219,11 +220,20 @@ class Dataframe(DataType):
                 if isinstance(ordered_jo[c], list):
                     data.append(ordered_jo[c])
                 else:
-                    data.append(ordered_jo[c].values())
+                    data.append(list(ordered_jo[c].values()))
 
-            #This goes in 'sideways' (cols=index, index=cols), so it needs to be transposed after to keep
-            #the correct structure
-            df = pd.DataFrame(data, columns=index, index=cols).transpose()
+            # This goes in 'sideways' (cols=index, index=cols), so it needs to be transposed after to keep
+            # the correct structure
+            # We also try to coerce the data to a regular numpy array first. If the shape is correct
+            # this is a much faster way of creating the DataFrame instance.
+            np_data = np.array(data)
+            if np_data.shape == (len(cols), len(index)):
+                df = pd.DataFrame(np_data, columns=index, index=cols).transpose()
+            else:
+                # TODO should these heterogenous structure be supported?
+                # See https://github.com/hydraplatform/hydra-base/issues/72
+                df = pd.DataFrame(data, columns=index, index=cols).transpose()
+
 
         except ValueError as e:
             """ Raised on scalar types used as pd.DataFrame values


### PR DESCRIPTION
This has a roughly 50x speed up when working with regular dataframes. If the parsed
shape is not compatible with the expected indices then the previous approach is used.