### PR TITLE
Re-introduced the use of unit_id in Scenario.py instead of unit

### DIFF
--- a/hydra_base/lib/scenario.py
+++ b/hydra_base/lib/scenario.py
@@ -770,14 +770,14 @@ def _update_resourcescenario(scenario, resource_scenario, dataset=None, new=Fals
         return None
 
     metadata = dataset.get_metadata_as_dict(source=source, user_id=user_id)
-    data_unit = dataset.unit
+    data_unit_id = dataset.unit_id
 
     data_hash = dataset.get_hash(value, metadata)
 
     assign_value(r_scen_i,
                  dataset.type.lower(),
                  value,
-                 data_unit,
+                 data_unit_id,
                  dataset.name,
                  metadata=metadata,
                  data_hash=data_hash,
@@ -786,7 +786,7 @@ def _update_resourcescenario(scenario, resource_scenario, dataset=None, new=Fals
     return r_scen_i
 
 def assign_value(rs, data_type, val,
-                 units, name, metadata={}, data_hash=None, user_id=None, source=None):
+                 unit_id, name, metadata={}, data_hash=None, user_id=None, source=None):
     """
         Insert or update a piece of data in a scenario.
         If the dataset is being shared by other resource scenarios, a new dataset is inserted.
@@ -828,7 +828,7 @@ def assign_value(rs, data_type, val,
 
     if update_dataset is True:
         log.info("Updating dataset '%s'", name)
-        dataset = data.update_dataset(rs.dataset.id, name, data_type, val, units, metadata, flush=False, **dict(user_id=user_id))
+        dataset = data.update_dataset(rs.dataset.id, name, data_type, val, unit_id, metadata, flush=False, **dict(user_id=user_id))
         rs.dataset = dataset
         rs.dataset_id = dataset.id
         log.info("Set RS dataset id to %s"%dataset.id)
@@ -836,7 +836,7 @@ def assign_value(rs, data_type, val,
         log.info("Creating new dataset %s in scenario %s", name, rs.scenario_id)
         dataset = data.add_dataset(data_type,
                                 val,
-                                units,
+                                unit_id,
                                 metadata=metadata,
                                 name=name,
                                 **dict(user_id=user_id))
@@ -879,7 +879,7 @@ def add_data_to_attribute(scenario_id, resource_attr_id, dataset,**kwargs):
 
     data_hash = dataset.get_hash(value, dataset_metadata)
 
-    assign_value(r_scen_i, data_type, value, dataset.unit, dataset.name,
+    assign_value(r_scen_i, data_type, value, dataset.unit_id, dataset.name,
                           metadata=dataset_metadata, data_hash=data_hash, user_id=user_id)
 
     db.DBSession.flush()


### PR DESCRIPTION
It is needed by unit_id select box. For some reason it has not been merged before