### PR TITLE
Change dependency to psycopg2-binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ testpkgs=[
 
 install_requires=[
     "sqlalchemy",
-    "psycopg2",
+    "psycopg2-binary",
     "zope.sqlalchemy >= 0.4",
     "pandas",
     "numpy",


### PR DESCRIPTION
Installing regular psycopg2 involves building from source and is a PITA.