### PR TITLE
107 failed login count

### DIFF
--- a/hydra_base/__init__.py
+++ b/hydra_base/__init__.py
@@ -47,6 +47,12 @@ log.debug("CONFIG sysfiles %s found in %s", len(config.sysfiles), config.sysfile
 if len(config.sysfiles) + len(config.repofiles) + len(config.userfiles) + len(config.sysfiles) == 0:
     log.critical("No config found. Please put your ini file into one of the files listed beside CONFIG above.")
 
+if config.get("security", "max_login_attempts") is None:
+    """  Absence of max_login_attempts results in all users unable to log in,
+         so ensure this is defined in config, or fail.
+    """
+    raise RuntimeError("Config 'security' section must define 'max_login_attempts'")
+
 log.debug(" \n ")
 
 from .lib.attributes import *

--- a/hydra_base/db/alembic/versions/50bd5bac8701_add_tuser_failed_logins.py
+++ b/hydra_base/db/alembic/versions/50bd5bac8701_add_tuser_failed_logins.py
@@ -1,0 +1,34 @@
+"""Add tUser.failed_logins
+
+Revision ID: 50bd5bac8701
+Revises: 35088e32c557
+Create Date: 2020-08-10 11:56:48.925174
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '50bd5bac8701'
+down_revision = '35088e32c557'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if op.get_bind().dialect.name == 'mysql':
+
+        try:
+            op.add_column('tUser', sa.Column('failed_logins', sa.types.SMALLINT, nullable=True))
+        except Exception as e:
+            log.exception(e)
+
+
+def downgrade():
+    if op.get_bind().dialect.name == 'mysql':
+
+        try:
+            op.drop_column('tUser', 'failed_logins')
+        except Exception as e:
+            log.exception(e)

--- a/hydra_base/db/model.py
+++ b/hydra_base/db/model.py
@@ -24,6 +24,7 @@ String,\
 LargeBinary,\
 TIMESTAMP,\
 BIGINT,\
+SMALLINT,\
 Float,\
 Text, \
 DateTime,\
@@ -1943,6 +1944,7 @@ class User(Base, Inspect):
     last_login = Column(TIMESTAMP())
     last_edit = Column(TIMESTAMP())
     cr_date = Column(TIMESTAMP(),  nullable=False, server_default=text(u'CURRENT_TIMESTAMP'))
+    failed_logins = Column(SMALLINT, nullable=True, default=0)
     roleusers = relationship('RoleUser', lazy='joined')
 
     _parents  = []

--- a/hydra_base/hydra.ini
+++ b/hydra_base/hydra.ini
@@ -85,3 +85,6 @@ page_size=2000
 
 [polyvis]
 POLYVIS_URL=http://localhost:5000/
+
+[security]
+max_login_attempts = 7

--- a/hydra_base/lib/users.py
+++ b/hydra_base/lib/users.py
@@ -126,6 +126,7 @@ def update_user_password(new_pwd_user_id, new_password,**kwargs):
     try:
         user_i = db.DBSession.query(User).filter(User.id==new_pwd_user_id).one()
         user_i.password = bcrypt.hashpw(str(new_password).encode('utf-8'), bcrypt.gensalt())
+        reset_failed_logins(user_i.username)
         return user_i
     except NoResultFound:
         raise ResourceNotFoundError("User (id=%s) not found"%(new_pwd_user_id))

--- a/hydra_base/lib/users.py
+++ b/hydra_base/lib/users.py
@@ -187,9 +187,14 @@ def get_failed_login_count(username, **kwargs):
 
 
 def get_max_login_attempts(*args, **kwargs):
-    max_login_attempts = int(config.get("security", "max_login_attempts"))
+    """  NOTE:
+         In the absence of max_login_attempts defined in config,
+         a value of 0 will be returned and users will be unable to log
+         in.
+    """
+    max_login_attempts = int(config.get("security", "max_login_attempts", 0))
 
-    return max_login_attempts if max_login_attempts is not None else 0
+    return max_login_attempts
 
 
 def get_remaining_login_attempts(username, **kwargs):

--- a/hydra_base/util/hdb.py
+++ b/hydra_base/util/hdb.py
@@ -29,7 +29,7 @@ from ..exceptions import HydraError
 import transaction
 from sqlalchemy.orm import load_only
 from ..lib.objects import JSONObject
-from ..lib.users import get_remaining_login_attempts, reset_failed_logins, inc_failed_login_attempts
+from ..lib.users import get_remaining_login_attempts, inc_failed_login_attempts
 
 import logging
 log = logging.getLogger(__name__)
@@ -135,8 +135,6 @@ def login_user(username, password):
         user_i = db.DBSession.query(User).filter(User.username == username).one()
     except NoResultFound:
         raise HydraError(username)
-
-    log.info("User {} has {} fails.".format(user_i.username, user_i.failed_logins))
 
     if get_remaining_login_attempts(username) <= 0:
         """  Account is not permitted to login """

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -236,3 +236,44 @@ class TestUser:
         role = client.get_role_by_code('admin')
 
         assert len(permissions) == len(role.roleperms)
+
+    def test_user_has_failed_login_count(self, client, user_json_object):
+        user = client.add_user(user_json_object)
+        failed_logins = client.get_failed_login_count(user.username)
+
+    def test_max_login_attempts_defined(self, client, user_json_object):
+        user = client.add_user(user_json_object)
+        max_attempts = client.get_max_login_attempts()
+        assert max_attempts is not None
+
+    def test_user_has_remaining_login_attempts(self, client, user_json_object):
+        user = client.add_user(user_json_object)
+        remaining_attempts = client.get_remaining_login_attempts(user.username)
+
+    def test_inc_user_failed_logins(self, client, user_json_object):
+        user = client.add_user(user_json_object)
+
+        initial_failed_logins = client.get_failed_login_count(user.username)
+        client.inc_failed_login_attempts(user.username)
+        final_failed_logins = client.get_failed_login_count(user.username)
+
+        assert final_failed_logins == initial_failed_logins + 1
+
+    def test_reset_user_failed_logins(self, client, user_json_object):
+        user = client.add_user(user_json_object)
+
+        client.inc_failed_login_attempts(user.username)
+        client.reset_failed_logins(user.username)
+        failed_logins = client.get_failed_login_count(user.username)
+
+        assert failed_logins == 0
+
+    def test_login_count_totals(self, client, user_json_object):
+        user = client.add_user(user_json_object)
+
+        client.inc_failed_login_attempts(user.username)
+        failed_logins = client.get_failed_login_count(user.username)
+        remaining_attempts = client.get_remaining_login_attempts(user.username)
+        max_attempts = client.get_max_login_attempts()
+
+        assert max_attempts == failed_logins + remaining_attempts


### PR DESCRIPTION
* Adds `failed_logins` to `tUser` with  Alembic script for migration
* `max_login_attempts` defined in `hydra.ini`
* Updates login behaviour in `login_user()`
* API in `lib.users`
* Tests in `test_users.py`

This is a prerequisite for hwi#631 and hwi#632, the failed-login-count and captcha issues.