### PR TITLE
add layout to Project

### DIFF
--- a/hydra_base/db/model.py
+++ b/hydra_base/db/model.py
@@ -746,6 +746,7 @@ class Project(Base, Inspect):
     id = Column(Integer(), primary_key=True, nullable=False)
     name = Column(String(200),  nullable=False, unique=False)
     description = Column(String(1000))
+    layout = Column(Text(2000), server_default=text(u'{}'))
     status = Column(String(1),  nullable=False, server_default=text(u"'A'"))
     cr_date = Column(TIMESTAMP(),  nullable=False, server_default=text(u'CURRENT_TIMESTAMP'))
     created_by = Column(Integer(), ForeignKey('tUser.id'), nullable=False)

--- a/hydra_base/db/model.py
+++ b/hydra_base/db/model.py
@@ -746,7 +746,7 @@ class Project(Base, Inspect):
     id = Column(Integer(), primary_key=True, nullable=False)
     name = Column(String(200),  nullable=False, unique=False)
     description = Column(String(1000))
-    layout = Column(Text(2000), server_default=text(u'{}'))
+    layout = Column(Text().with_variant(mysql.LONGTEXT, 'mysql'),  nullable=True)
     status = Column(String(1),  nullable=False, server_default=text(u"'A'"))
     cr_date = Column(TIMESTAMP(),  nullable=False, server_default=text(u'CURRENT_TIMESTAMP'))
     created_by = Column(Integer(), ForeignKey('tUser.id'), nullable=False)


### PR DESCRIPTION
This adds layout to the Project class (see issue #20 ), in a manner consistent with other layout fields:
```
layout = Column(Text().with_variant(mysql.LONGTEXT, 'mysql'),  nullable=True)
```
