### PR TITLE
make sure scenario ID is int before comparing to zero

### DIFF
--- a/hydra_base/lib/scenario.py
+++ b/hydra_base/lib/scenario.py
@@ -218,7 +218,7 @@ def add_scenario(network_id, scenario,**kwargs):
     scen.resourcegroupitems   = []
 
     #Just in case someone puts in a negative ID for the scenario.
-    if scenario.id < 0:
+    if isinstance(scenario.id, int) and scenario.id < 0:
         scenario.id = None
 
     if scenario.resourcescenarios is not None:


### PR DESCRIPTION
This is a simple fix when adding a scenario when scenario.id is None. Without this, the scenario ID might be None and compared against zero, which Python doesn't like. Some variation of this could be implemented as well (e.g., check if scenario.id is str?)