### PR TITLE
Compress value column

### DIFF
--- a/hydra_base/db/__init__.py
+++ b/hydra_base/db/__init__.py
@@ -102,15 +102,13 @@ def create_mysql_db(db_url):
             else:
                 no_db_url = db_url
                 db_url = no_db_url + "/" + db_name
-
-        if db_url.find('charset=utf8&use_unicode=1') == -1:
+        if db_url.find('charset') == -1:
             db_url = "{}?charset=utf8&use_unicode=1".format(db_url)
 
         if config.get('mysqld', 'auto_create', 'Y') == 'Y':
             tmp_engine = create_engine(no_db_url)
             log.debug("Creating database {0} as it does not exist.".format(db_name))
             tmp_engine.execute("CREATE DATABASE IF NOT EXISTS {0}".format(db_name))
-
     return db_url
 
 def connect(db_url=None):
@@ -156,7 +154,6 @@ def connect(db_url=None):
     DBSession = scoped_session(maker)
     register(DBSession)
 
-
     global DeclarativeBase
     try:
         DeclarativeBase.metadata.create_all(engine, checkfirst=True)
@@ -173,12 +170,27 @@ def commit_transaction():
     try:
         transaction.commit()
     except Exception as e:
-        #import pudb; pudb.set_trace()
         log.critical(e)
         transaction.abort()
 
+def open_session():
+    log.debug("OPENING SESSION")
+
+    global DBSession
+
+    from .model import User
+    session = DBSession()
+    session.query(User).all()
+
+    session2 = DBSession()
+    session2.query(User).all()
+
+    DBSession()
+
 def close_session():
+    log.debug("CLOSING SESSION")
     DBSession.remove()
+
 
 def rollback_transaction():
     #import pudb; pudb.set_trace()

--- a/hydra_base/db/alembic.ini
+++ b/hydra_base/db/alembic.ini
@@ -35,7 +35,7 @@ script_location = alembic
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = mysql+mysqlconnector://root:root@localhost/hydradb
+sqlalchemy.url = mysql+mysqldb://root:root@localhost/hydradb
 
 
 # Logging configuration

--- a/hydra_base/db/alembic/versions/9b463e64e644_dataset_value_blob.py
+++ b/hydra_base/db/alembic/versions/9b463e64e644_dataset_value_blob.py
@@ -1,0 +1,36 @@
+"""dataset_value_blob
+
+Revision ID: 9b463e64e644
+Revises: cec2b77ad85e
+Create Date: 2022-05-03 21:17:43.525108
+
+"""
+import logging
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+log = logging.getLogger(__name__)
+
+# revision identifiers, used by Alembic.
+revision = '9b463e64e644'
+down_revision = 'cec2b77ad85e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if op.get_bind().dialect.name == 'mysql':
+
+        try:
+            op.alter_column('tDataset', 'value', existing_type=sa.Text().with_variant(mysql.LONGTEXT, 'mysql'), type_=sa.LargeBinary(length=(2**32)-1))
+        except Exception as e:
+            log.critical(e)
+
+
+def downgrade():
+        if op.get_bind().dialect.name == 'mysql':
+            try:
+                op.alter_column('tDataset', 'value', existing_type=sa.LargeBinary(), type_=sa.Text().with_variant(mysql.LONGTEXT, 'mysql'))
+            except Exception as e:
+                log.critical(e)

--- a/hydra_base/db/model.py
+++ b/hydra_base/db/model.py
@@ -297,7 +297,7 @@ class Dataset(Base, Inspect, PermissionControlled, AuditMixin):
         """
             Get the uncompressed value
         """
-        return str(self.value_uncompressed)
+        return self.value_uncompressed.decode('utf-8')
 
     def set_metadata(self, metadata_tree):
         """
@@ -1942,7 +1942,9 @@ class ResourceScenario(Base, Inspect):
                 Dataset.name,
                 Dataset.hidden,
                 case([(and_(Dataset.hidden=='Y', DatasetOwner.user_id is not None), None)],
-                        else_=Dataset.value).label('value')).filter(
+                        else_=Dataset.value).label('value'),
+                case([(and_(Dataset.hidden=='Y', DatasetOwner.user_id is not None), None)],
+                        else_=Dataset.value_uncompressed).label('value_uncompressed')).filter(
                 Dataset.id==self.id).outerjoin(DatasetOwner,
                                     and_(Dataset.id==DatasetOwner.dataset_id,
                                     DatasetOwner.user_id==user_id)).one()

--- a/hydra_base/db/model.py
+++ b/hydra_base/db/model.py
@@ -2097,6 +2097,7 @@ class Scenario(Base, Inspect):
                     ResourceScenario.resource_attr_id,
                     ResourceScenario.source,
                     ResourceAttr.attr_id,
+                    ResourceAttr.attr_is_var,
                     ResourceAttr.ref_key,
                     ResourceAttr.node_id,
                     ResourceAttr.network_id,
@@ -2119,7 +2120,7 @@ class Scenario(Base, Inspect):
             rs_qry = rs_qry.filter(ResourceAttr.attr_is_var=='Y')
 
         if ra_ids is not None:
-            rs_query = rs_qry.filter(ResourceScenario.resource_attr_id.in_(ra_ids))
+            rs_qry = rs_qry.filter(ResourceScenario.resource_attr_id.in_(ra_ids))
 
         all_rs = rs_qry.all()
 
@@ -2131,7 +2132,9 @@ class Scenario(Base, Inspect):
                 'dataset_id':rs.dataset_id
             })
             rs_attr = JSONObject({
+                'id': rs.resource_attr_id,
                 'attr_id':rs.attr_id,
+                'attr_is_var': rs.attr_is_var,
                 'ref_key': rs.ref_key,
                 'node_id': rs.node_id,
                 'link_id': rs.link_id,

--- a/hydra_base/db/model.py
+++ b/hydra_base/db/model.py
@@ -288,7 +288,7 @@ class Dataset(Base, Inspect, PermissionControlled, AuditMixin):
     hash       = Column(BIGINT(),  nullable=False, unique=True)
     cr_date    = Column(TIMESTAMP(),  nullable=False, server_default=text(u'CURRENT_TIMESTAMP'))
     hidden     = Column(String(1),  nullable=False, server_default=text(u"'N'"))
-    value      = Column('value', LargeBinary(),  nullable=True)
+    value      = Column('value', LargeBinary(length=(2**32)-1),  nullable=True)
 
     value_uncompressed_col = column_property(func.uncompress(value), raiseload=False, deferred=True)
     unit = relationship('Unit', backref=backref("dataset_unit", order_by=unit_id))

--- a/hydra_base/hydra.ini
+++ b/hydra_base/hydra.ini
@@ -77,7 +77,7 @@ default_file = %(hydra_base_dir)s/static/unit_definitions.xml
 template_xsd_path   = %(hydra_base_dir)s/static/template.xsd
 
 [logging_conf]
-log_config_path =  %(hydra_base_dir)s/config/logging.conf
+log_config_path =  %(hydra_base_dir)s/logging.conf
 log_file_dir =  %(hydra_aux_dir)s/log
 
 [search]

--- a/hydra_base/lib/data.py
+++ b/hydra_base/lib/data.py
@@ -424,7 +424,8 @@ def update_dataset(dataset_id, name, data_type, val, unit_id, metadata={}, flush
             locked_scenarios.append(dataset_rs)
         else:
             unlocked_scenarios.append(dataset_rs)
-
+    if isinstance(val, str):
+        val = val.encode('utf-8')
     #Are any of these scenarios locked?
     if len(locked_scenarios) > 0:
         #If so, create a new dataset and assign to all unlocked datasets.
@@ -471,6 +472,9 @@ def add_dataset(data_type, val, unit_id=None, metadata={}, name="", user_id=None
     """
 
     d = Dataset()
+
+    if isinstance(val, str):
+        val = val.encode('utf-8')
 
     d.type  = data_type
     d.value = val
@@ -638,7 +642,7 @@ def _process_incoming_data(data, user_id=None, source=None):
 
     datasets = {}
     for d in data:
-        val = d.parse_value()
+        val = d.parse_value().encode('utf-8')
 
         if val is None:
             log.info("Cannot parse data (dataset_id=%s). "

--- a/hydra_base/lib/data.py
+++ b/hydra_base/lib/data.py
@@ -80,6 +80,8 @@ def get_dataset(dataset_id,**kwargs):
                 DatasetOwner.user_id,
                 null().label('metadata'),
                 case([(and_(Dataset.hidden=='Y', DatasetOwner.user_id is not None), None)],
+                        else_=Dataset.value_uncompressed).label('value_uncompressed'),
+                case([(and_(Dataset.hidden=='Y', DatasetOwner.user_id is not None), None)],
                         else_=Dataset.value).label('value')).filter(
                 Dataset.id==dataset_id).outerjoin(DatasetOwner,
                                     and_(DatasetOwner.dataset_id==Dataset.id,

--- a/hydra_base/lib/network.py
+++ b/hydra_base/lib/network.py
@@ -975,6 +975,7 @@ def _get_all_resourcescenarios(network_id, scenario_ids, include_results, user_i
                 Dataset.created_by,
                 Dataset.hidden,
                 Dataset.value,
+                Dataset.value_uncompressed,
                 ResourceScenario.dataset_id,
                 ResourceScenario.scenario_id,
                 ResourceScenario.resource_attr_id,
@@ -1005,9 +1006,6 @@ def _get_all_resourcescenarios(network_id, scenario_ids, include_results, user_i
     for rs in all_rs:
         rs_obj = JSONObject(rs)
         rs_attr = JSONObject({'attr_id':rs.attr_id})
-
-        value = rs.value
-
         rs_dataset = JSONDataset({
             'id':rs.dataset_id,
             'type' : rs.type,
@@ -1017,7 +1015,8 @@ def _get_all_resourcescenarios(network_id, scenario_ids, include_results, user_i
             'cr_date':rs.cr_date,
             'created_by':rs.created_by,
             'hidden':rs.hidden,
-            'value':value,
+            'value':rs.value,
+            'value_uncompressed':rs.value_uncompressed,
             'metadata':{},
         })
         rs_obj.resourceattr = rs_attr

--- a/hydra_base/lib/objects.py
+++ b/hydra_base/lib/objects.py
@@ -228,17 +228,17 @@ class Dataset(JSONObject):
     def __init__(self, dataset={}, parent=None, extras={}):
 
         super(Dataset, self).__init__(dataset, parent=parent, extras=extras)
-        uncompressed_value = None
+        value_uncompressed = None
         if hasattr(dataset, 'value_uncompressed'):
-            uncompressed_value = dataset.value_uncompressed
+            value_uncompressed = dataset.value_uncompressed
         elif dataset.get('value_uncompressed') is not None:
-            uncompressed_value = dataset['value_uncompressed']
+            value_uncompressed = dataset['value_uncompressed']
 
-        if uncompressed_value is not None:
+        if value_uncompressed is not None:
             try:
-                self.value = str(uncompressed_value.decode('utf-8'))
+                self.value = value_uncompressed.decode('utf-8')
             except AttributeError:
-                self.value = uncompressed_value
+                self.value = value_uncompressed
 
         if self.get('value_uncompressed') is not None:
             del(self['value_uncompressed'])
@@ -260,6 +260,16 @@ class Dataset(JSONObject):
                     pass
             value = six.text_type(value)
         super(Dataset, self).__setattr__(name, value)
+
+    def get_value(self):
+        """
+            This function is here to match the equivalent one on the tDataset class in model.py
+            so that the get_value function can be used throughout to replace the '.value' property
+            which now may contain compressed data.
+            This should return a string value for the dataset's value rather than the compressed
+            value
+        """
+        return self.value
 
     def parse_value(self):
         """

--- a/hydra_base/lib/sharing.py
+++ b/hydra_base/lib/sharing.py
@@ -262,6 +262,12 @@ def hide_dataset(dataset_id, exceptions, read, write, share,**kwargs):
 
     user_id = kwargs.get('user_id')
     dataset_i = _get_dataset(dataset_id)
+
+    #this is important as otherwise the DB trigger will attempt to re-compress the
+    #compressed value on saving to the DB
+    if hasattr(dataset_i, 'value_uncompressed'):
+        dataset_i.value = dataset_i.value_uncompressed
+
     #check that I can hide the dataset
     if dataset_i.created_by != int(user_id):
         raise HydraError('Permission denied. '

--- a/hydra_base/lib/units.py
+++ b/hydra_base/lib/units.py
@@ -590,7 +590,7 @@ def convert_dataset(dataset_id, target_unit_abbreviation,**kwargs):
 
         new_dataset = Dataset()
         new_dataset.type   = ds_i.type
-        new_dataset.value  = str(new_val) # The data type is TEXT!!!
+        new_dataset.value  = str(new_val).encode('utf-8') # The data type is Binary so needs encoding.
         new_dataset.name   = ds_i.name
 
         new_dataset.unit_id   = get_unit_by_abbreviation(target_unit_abbreviation).id

--- a/hydra_base/util/__init__.py
+++ b/hydra_base/util/__init__.py
@@ -131,21 +131,26 @@ def get_val(dataset, timestamp=None):
         for example) or as a single python dictionary
 
     """
+
+    val = dataset.get_value()
+
+    if isinstance(val, bytes):
+        val = val.decode('utf-8')
+
     if dataset.type == 'array':
         #TODO: design a mechansim to retrieve this data if it's stored externally
-        return json.loads(dataset.value)
+        return json.loads(val)
 
     elif dataset.type == 'descriptor':
-        return str(dataset.value)
+        return str(val)
     elif dataset.type == 'scalar':
-        return Decimal(str(dataset.value))
+        return Decimal(str(val))
     elif dataset.type == 'timeseries':
         #TODO: design a mechansim to retrieve this data if it's stored externally
-        val = dataset.value
 
         seasonal_year = config.get('DEFAULT','seasonal_year', '1678')
         seasonal_key = config.get('DEFAULT', 'seasonal_key', '9999')
-        val = dataset.value.replace(seasonal_key, seasonal_year)
+        val = val.replace(seasonal_key, seasonal_year)
 
         timeseries = pd.read_json(val, convert_axes=True)
 

--- a/hydra_base/util/dataset_util.py
+++ b/hydra_base/util/dataset_util.py
@@ -132,6 +132,7 @@ def _get_val(val, full=False):
         values. In the special case of timeseries, when a check is for time-based
         criteria, you can return the entire timeseries.
     """
+
     try:
         val = val.strip()
     except:

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -72,6 +72,13 @@ class TestAttribute:
 
         assert len(all_attributes) == len(all_attributes_insert_2)
 
+        upper_case_attr = test_attr
+        upper_case_attr['name'] = upper_case_attr['name'].upper()
+
+        new_upper_attr = client.add_attribute(upper_case_attr)
+
+        assert new_upper_attr['id'] == new_attr['id']
+
 
     def test_update_attribute(self, client):
         test_attr = JSONObject({
@@ -139,8 +146,13 @@ class TestAttribute:
 
         all_attributes_after_add_1 = client.get_attributes()
 
+        #test to make sure that the insert is not case-sensitive.
+        upper_test_attrs = test_attrs
+        for a in upper_test_attrs:
+            a['name'] = a['name'].upper()
+
         #Try adding the attributes again. It should ignore them as theyr'e already there.
-        new_attrs_list_2 = client.add_attributes(test_attrs)
+        new_attrs_list_2 = client.add_attributes(upper_test_attrs)
 
         all_attributes_after_add_2 = client.get_attributes()
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -20,6 +20,8 @@
 import pytest
 import hydra_base as hb
 from hydra_base.lib.objects import JSONObject
+from hydra_base.exceptions import HydraError
+
 
 import logging
 log = logging.getLogger(__name__)
@@ -152,7 +154,7 @@ class TestGroup:
             #In these tests, all timeseries are unique to their resources,
             #so after removing the group no timeseries to which it was attached
             #should still exist.
-            d = rs.value
+            d = rs.dataset
             if d.type == 'timeseries':
-                with pytest.raises(hydra_base.HydraError):
+                with pytest.raises(HydraError):
                     client.get_dataset(d.id)

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -257,6 +257,7 @@ class TestScenario:
 
         rs_to_update = []
         updated_dataset_id = None
+        scenario = client.get_scenario(scenario.id, include_data=True)
         for resourcescenario in scenario.resourcescenarios:
             ra_id = resourcescenario.resource_attr_id
             if ra_id == descriptor.resource_attr_id:
@@ -380,7 +381,7 @@ class TestScenario:
         rs_to_update = self._get_rs_to_update(scenario_2, scalar)
 
         new_resourcescenarios = client.update_resourcedata(scenario_2.id,
-                                                                        rs_to_update)
+                                                           rs_to_update)
         rs_2_id = None
         #Check that scenario 2 has been updated correctly.
         updated_scenario_2 = client.get_scenario(scenario_2.id)


### PR DESCRIPTION
This is a backward-compatible change to allow the tDataset.value column to be compressed.
This works with mysql databases where the tDataset column is not compressed.
The compression occurs in a trigger on insert and update, while decompression occurs in the ORM.
All tests pass on both sqlite and mysql.