### PR TITLE
164 extracting subsets of data from large external sources

### DIFF
--- a/hydra_base/hydra.ini
+++ b/hydra_base/hydra.ini
@@ -49,6 +49,7 @@ direct_location_token = mongo_direct
 value_location_key = value_storage_location
 
 [storage_hdf]
+disable_hdf = False
 hdf_filestore = /tmp/hdf
 
 [hydra_server]

--- a/hydra_base/hydra.ini
+++ b/hydra_base/hydra.ini
@@ -48,6 +48,9 @@ threshold = 4096
 direct_location_token = mongo_direct
 value_location_key = value_storage_location
 
+[storage_hdf]
+hdf_filestore = /tmp/hdf
+
 [hydra_server]
 domain = 127.0.0.1
 port = 8080

--- a/hydra_base/lib/data.py
+++ b/hydra_base/lib/data.py
@@ -1099,6 +1099,7 @@ def read_json(json_string):
 def get_hdf_filesize(url, **kwargs):
     """
       Returns the size in bytes of the hdf file <url> argument
+      Raises ValueError on bad url
     """
     hdf = HdfStorageAdapter()
     return hdf.size(url)
@@ -1111,6 +1112,7 @@ def get_hdf_info(url, dataset_name, **kwargs):
         "size": int: Number of rows in dataset series,
         "dtype": str: The numpy.dtype of the dataset
       }
+      Raises ValueError on bad url or dataset name
     """
     hdf = HdfStorageAdapter()
     return hdf.get_dataset_info_url(url, dataset_name)
@@ -1121,6 +1123,7 @@ def get_hdf_dataframe(url, dataset_name, start, end, **kwargs):
       the hdf file <url> as the json representation of a Pandas
       DataFrame. This may then be read directly in a client with
       pandas.read_json().
+      Raises ValueError on bad url, dataset name or bounds.
     """
     hdf = HdfStorageAdapter()
     return hdf.hdf_dataset_to_pandas_dataframe(url, dataset_name, start, end)

--- a/hydra_base/lib/data.py
+++ b/hydra_base/lib/data.py
@@ -1104,7 +1104,7 @@ def get_hdf_filesize(url, **kwargs):
     hdf = HdfStorageAdapter()
     return hdf.size(url)
 
-def get_hdf_info(url, dataset_name, **kwargs):
+def get_hdf_dataset_info(url, dataset_name, **kwargs):
     """
       Returns information about the <dataset_name> argument:
       {
@@ -1123,7 +1123,25 @@ def get_hdf_dataframe(url, dataset_name, start, end, **kwargs):
       the hdf file <url> as the json representation of a Pandas
       DataFrame. This may then be read directly in a client with
       pandas.read_json().
-      Raises ValueError on bad url, dataset name or bounds.
+      Raises ValueError on bad url, dataset name or bounds
     """
     hdf = HdfStorageAdapter()
     return hdf.hdf_dataset_to_pandas_dataframe(url, dataset_name, start, end)
+
+def resolve_url_to_path(url, **kwargs):
+    hdf = HdfStorageAdapter()
+    """
+      Returns the path, either on a local filesystem or remote
+      storage, to which the <url> arg resolves.
+      Raises ValueError if the arg cannot be interpreted as a valid url
+    """
+    return hdf.url_to_filestore_path(url)
+
+def file_exists_at_url(url, **kwargs):
+    """
+      Return a boolean corresponding to the existence of a readable
+      file at the <url> arg.
+      Never raises, returns False for invalid args or no permission
+    """
+    hdf = HdfStorageAdapter()
+    return hdf.file_exists_at_url(url)

--- a/hydra_base/lib/data.py
+++ b/hydra_base/lib/data.py
@@ -42,7 +42,10 @@ from ..exceptions import HydraError, PermissionError, ResourceNotFoundError
 from ..util import generate_data_hash
 from ..util.hydra_dateutil import get_datetime
 
-from hydra_base.lib.storage import MongoStorageAdapter
+from hydra_base.lib.storage import (
+    MongoStorageAdapter,
+    HdfStorageAdapter
+)
 
 
 global FORMAT
@@ -1092,3 +1095,32 @@ def delete_dataset(dataset_id,**kwargs):
 
 def read_json(json_string):
     pd.read_json(json_string)
+
+def get_hdf_filesize(url, **kwargs):
+    """
+      Returns the size in bytes of the hdf file <url> argument
+    """
+    hdf = HdfStorageAdapter()
+    return hdf.size(url)
+
+def get_hdf_info(url, dataset_name, **kwargs):
+    """
+      Returns information about the <dataset_name> argument:
+      {
+        "name": str: Name of the dataset,
+        "size": int: Number of rows in dataset series,
+        "dtype": str: The numpy.dtype of the dataset
+      }
+    """
+    hdf = HdfStorageAdapter()
+    return hdf.get_dataset_info_url(url, dataset_name)
+
+def get_hdf_dataframe(url, dataset_name, start, end, **kwargs):
+    """
+      Returns the rows from <start> to <end> of <dataset_name> in
+      the hdf file <url> as the json representation of a Pandas
+      DataFrame. This may then be read directly in a client with
+      pandas.read_json().
+    """
+    hdf = HdfStorageAdapter()
+    return hdf.hdf_dataset_to_pandas_dataframe(url, dataset_name, start, end)

--- a/hydra_base/lib/storage/__init__.py
+++ b/hydra_base/lib/storage/__init__.py
@@ -8,3 +8,4 @@ from .mongodatasetmanager import MongoDatasetManager
 
 """ Storage adapters """
 from .mongostorageadapter import MongoStorageAdapter
+from .hdfstorageadapter import HdfStorageAdapter

--- a/hydra_base/lib/storage/hdfstorageadapter.py
+++ b/hydra_base/lib/storage/hdfstorageadapter.py
@@ -196,39 +196,3 @@ def nscale(ts):
       into instances of datetime.timestamp
     """
     return datetime.fromtimestamp(ts/1e9)
-
-
-
-
-if __name__ == "__main__":
-    bad_url = "does_not_exist.h5"
-    bad_aws_url = "s3://modelers-data-bucket/eapp/single/does_not_exist.h5"
-    path_url = "path:///home/paul/data/eapp_new/data/ETH_flow_sim.h5"
-    fs_url = "ETH_flow_sim.h5"
-    remote_url = "s3://terrafusiondatasampler/P233/TERRA_BF_L1B_O12236_20020406135439_F000_V001.h5"
-    aws_url = "s3://modelers-data-bucket/eapp/single/ETH_flow_sim.h5"
-    dsn = "BR_Kabura"
-
-    hsa = HdfStorageAdapter()
-    print(f"{hsa.config=}")
-    print()
-
-    block_info = hsa.get_dataset_info_url(bad_aws_url, dsn)
-    print(block_info)
-    block_info = hsa.get_dataset_info_file(fs_url, dsn)
-    print(block_info)
-    block_info = hsa.get_dataset_info_url(fs_url, dsn)
-    print(block_info)
-    print()
-    block_data = hsa.get_dataset_block_file(fs_url, dsn, 8, 16)
-    print(block_data)
-    block_data = hsa.get_dataset_block_file(fs_url, dsn, 12008, 12016)
-    print(block_data)
-    df = hsa.hdf_dataset_to_pandas_dataframe(aws_url, dsn, 8, 16)
-    print(df)
-    df = hsa.hdf_dataset_to_pandas_dataframe(aws_url, dsn, 12008, 12016)
-    print(df)
-    print(f"{hsa.size(path_url)=}")
-    print(f"{hsa.size(remote_url)=}")
-    print(f"{hsa.size(aws_url)=}")
-    #import pudb; pudb.set_trace()

--- a/hydra_base/lib/storage/hdfstorageadapter.py
+++ b/hydra_base/lib/storage/hdfstorageadapter.py
@@ -1,0 +1,117 @@
+import fsspec
+import h5py
+import logging
+import pandas as pd
+from datetime import datetime
+
+from hydra_base import config
+
+log = logging.getLogger(__name__)
+
+
+class HdfStorageAdapter():
+    """
+       Utilities to describe and retrieve data from HDF storage
+    """
+
+    def __init__(self):
+        pass
+
+
+    def open_hdf_url(self, url):
+        """
+          Add local filestore from config
+        """
+        s3f = fsspec.open(url, mode='rb', anon=True, default_fill_cache=False)
+        return h5py.File(s3f.open(), mode='r')
+
+
+    def get_dataset_info(self, url, dsname):
+        df = pd.read_hdf(url)
+        series = df[dsname]
+        index = df.index
+        info = {
+          "index":  {"name": index.name,
+                     "length": len(index),
+                     "dtype": str(index.dtype)
+                    },
+          "series": {"name": series.name,
+                     "length": len(series),
+                     "dtype": str(series.dtype)
+                    }
+        }
+        return info
+
+
+    def get_dataset_block(self, url, dsname, start, end):
+        df = pd.read_hdf(url)
+        section = df[dsname][start:end]
+        block_index = section.index.map(str).tolist()
+        block_values = section.values.tolist()
+
+        return {
+            "index": block_index,
+            "series": block_values
+        }
+
+
+    def hdf_dataset_to_pandas_dataframe(self, url, dsname, start, end):
+        h5f = self.open_hdf_url(url)
+        """
+          Pywr uses hdf group names implicitly and these vary by dataset type.
+          Assume the first key of the hdf doc represents a group containing
+          the [axis0, axis1, block0_index, block0_values] constituents of a
+          Pandas dataframe.
+        """
+
+        groupname = [*h5f.keys()][0]
+        try:
+            group = h5f[groupname]
+            bcols = group["axis0"][:]
+        except KeyError as ke:
+            raise ValueError(f"Data source {url} has invalid structure") from ke
+
+        cols = [*map(bytes.decode, bcols)]
+
+        try:
+            series_col = cols.index(dsname)
+        except ValueError as ve:
+            raise ValueError(f"No series '{dsname}' in {url}") from ve
+
+        ts_nano = group["axis1"][start:end]
+        ts_sec = [*map(nscale, ts_nano)]
+        timestamps = [*map(str, ts_sec)]
+
+        val_ds = group["block0_values"]
+        val_rows = val_ds.shape[0]
+
+        if start < 0 or start >= val_rows or start >= end or end < 0 or end >= val_rows:
+            raise ValueError(f"Invalid section in dataset of size {val_rows}: {start=}, {end=}")
+
+        val_sect = val_ds[start:end]
+        section = [ i[0] for i in val_sect[:, series_col:series_col+1].tolist() ]
+
+        df = pd.DataFrame({dsname: section}, index=pd.DatetimeIndex(timestamps))
+        return df
+
+
+def nscale(ts):
+    """
+      Transforms integers representing nanoseconds past the epoch
+      into instances of datetime.timestamp
+    """
+    return datetime.fromtimestamp(ts/1e9)
+
+
+if __name__ == "__main__":
+    url = "/home/paul/data/eapp_new/data/ETH_flow_sim.h5"
+    dsn = "BR_Kabura"
+    hsa = HdfStorageAdapter()
+
+    block_info = hsa.get_dataset_info(url, dsn)
+    print(block_info)
+    block_data = hsa.get_dataset_block(url, dsn,8, 16)
+    print(block_data)
+    df = hsa.hdf_dataset_to_pandas_dataframe(url, dsn, 8, 16)
+    print(df)
+    #import pudb; pudb.set_trace()

--- a/hydra_base/lib/storage/hdfstorageadapter.py
+++ b/hydra_base/lib/storage/hdfstorageadapter.py
@@ -158,33 +158,3 @@ def nscale(ts):
       into instances of datetime.timestamp
     """
     return datetime.fromtimestamp(ts/1e9)
-
-
-if __name__ == "__main__":
-    path_url = "path:///home/paul/data/eapp_new/data/ETH_flow_sim.h5"
-    fs_url = "ETH_flow_sim.h5"
-    remote_url = "s3://terrafusiondatasampler/P233/TERRA_BF_L1B_O12236_20020406135439_F000_V001.h5"
-    aws_url = "s3://modelers-data-bucket/eapp/single/ETH_flow_sim.h5"
-    dsn = "BR_Kabura"
-
-    hsa = HdfStorageAdapter()
-    print(f"{hsa.config=}")
-    print()
-
-    block_info = hsa.get_dataset_info_file(fs_url, dsn)
-    print(block_info)
-    block_info = hsa.get_dataset_info_url(fs_url, dsn)
-    print(block_info)
-    print()
-    block_data = hsa.get_dataset_block_file(fs_url, dsn, 8, 16)
-    print(block_data)
-    block_data = hsa.get_dataset_block_file(fs_url, dsn, 12008, 12016)
-    print(block_data)
-    df = hsa.hdf_dataset_to_pandas_dataframe(aws_url, dsn, 8, 16)
-    print(df)
-    df = hsa.hdf_dataset_to_pandas_dataframe(aws_url, dsn, 12008, 12016)
-    print(df)
-    print(f"{hsa.size(path_url)=}")
-    print(f"{hsa.size(remote_url)=}")
-    print(f"{hsa.size(aws_url)=}")
-    #import pudb; pudb.set_trace()

--- a/hydra_base/lib/storage/hdfstorageadapter.py
+++ b/hydra_base/lib/storage/hdfstorageadapter.py
@@ -15,19 +15,27 @@ class HdfStorageAdapter():
     """
 
     def __init__(self):
-        pass
+        self.config = self.__class__.get_hdf_config()
 
+    @staticmethod
+    def get_hdf_config(config_key="storage_hdf"):
+        numeric = ()
+        hdf_keys = [k for k in config.CONFIG.options(config_key) if k not in config.CONFIG.defaults()]
+        hdf_items = {k: config.CONFIG.get(config_key, k) for k in hdf_keys}
+        for k in numeric:
+            hdf_items[k] = int(hdf_items[k])
+
+        return hdf_items
 
     def open_hdf_url(self, url):
         """
           Add local filestore from config
         """
-        s3f = fsspec.open(url, mode='rb', anon=True, default_fill_cache=False)
-        return h5py.File(s3f.open(), mode='r')
+        with fsspec.open(url, mode='rb', anon=True, default_fill_cache=False) as s3f:
+            return h5py.File(s3f.fs.open(url), mode='r')
 
-
-    def get_dataset_info(self, url, dsname):
-        df = pd.read_hdf(url)
+    def get_dataset_info_file(self, filepath, dsname):
+        df = pd.read_hdf(filepath)
         series = df[dsname]
         index = df.index
         info = {
@@ -42,9 +50,8 @@ class HdfStorageAdapter():
         }
         return info
 
-
-    def get_dataset_block(self, url, dsname, start, end):
-        df = pd.read_hdf(url)
+    def get_dataset_block_file(self, filepath, dsname, start, end):
+        df = pd.read_hdf(filepath)
         section = df[dsname][start:end]
         block_index = section.index.map(str).tolist()
         block_values = section.values.tolist()
@@ -54,6 +61,11 @@ class HdfStorageAdapter():
             "series": block_values
         }
 
+    def size(self, url):
+        with fsspec.open(url, mode='rb', anon=True, default_fill_cache=False) as fp:
+            size_bytes = fp.fs.size(fp.path)
+
+        return size_bytes
 
     def hdf_dataset_to_pandas_dataframe(self, url, dsname, start, end):
         h5f = self.open_hdf_url(url)
@@ -91,8 +103,36 @@ class HdfStorageAdapter():
         val_sect = val_ds[start:end]
         section = [ i[0] for i in val_sect[:, series_col:series_col+1].tolist() ]
 
+        h5f.close()
+
         df = pd.DataFrame({dsname: section}, index=pd.DatetimeIndex(timestamps))
-        return df
+        return df.to_json()
+
+    def get_dataset_info_url(self, url, dsname):
+        h5f = self.open_hdf_url(url)
+
+        groupname = [*h5f.keys()][0]
+        try:
+            group = h5f[groupname]
+            bcols = group["axis0"][:]
+        except KeyError as ke:
+            raise ValueError(f"Data source {url} has invalid structure") from ke
+
+        cols = [*map(bytes.decode, bcols)]
+
+        try:
+            series_col = cols.index(dsname)
+        except ValueError as ve:
+            raise ValueError(f"No series '{dsname}' in {url}") from ve
+
+        val_ds = group["block0_values"]
+        val_rows = val_ds.shape[0]
+
+        return {
+            "name": dsname,
+            "size": val_rows,
+            "dtype": str(val_ds.dtype)
+        }
 
 
 def nscale(ts):
@@ -105,13 +145,22 @@ def nscale(ts):
 
 if __name__ == "__main__":
     url = "/home/paul/data/eapp_new/data/ETH_flow_sim.h5"
+    remote_url = "s3://terrafusiondatasampler/P233/TERRA_BF_L1B_O12236_20020406135439_F000_V001.h5"
     dsn = "BR_Kabura"
-    hsa = HdfStorageAdapter()
 
-    block_info = hsa.get_dataset_info(url, dsn)
+    hsa = HdfStorageAdapter()
+    print(f"{hsa.config=}")
+    print()
+
+    block_info = hsa.get_dataset_info_file(url, dsn)
     print(block_info)
-    block_data = hsa.get_dataset_block(url, dsn,8, 16)
+    block_info = hsa.get_dataset_info_url(url, dsn)
+    print(block_info)
+    print()
+    block_data = hsa.get_dataset_block_file(url, dsn, 8, 16)
     print(block_data)
     df = hsa.hdf_dataset_to_pandas_dataframe(url, dsn, 8, 16)
     print(df)
+    print(f"{hsa.size(url)=}")
+    #print(hsa.size(remote_url))
     #import pudb; pudb.set_trace()

--- a/hydra_base/util/__init__.py
+++ b/hydra_base/util/__init__.py
@@ -245,3 +245,40 @@ def get_json_as_dict(json_string_or_dict):
             return get_json_as_dict(json.loads(json_string_or_dict))
         except:
             return json_string_or_dict
+
+
+class NullAdapterType(type):
+    """
+      Metaclass for NullAdapter. Overriding __getattr__ here
+      enables class and static attrs to be simulated.
+    """
+    def __getattr__(self, *args, **kwargs):
+        return self
+
+
+class NullAdapter(metaclass=NullAdapterType):
+    """
+      A class that does nothing.
+      This may be used in place of any adapter in order to disable
+      the functionality of that adapter type without requiring other
+      code to be changed.
+      From the caller's perspective, all attributes exist on this class,
+      including nested attributes, and all are callable.
+    """
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def __getattr__(self, *args, **kwargs):
+        return self
+
+    def __getitem__(self, idx):
+        return None
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise StopIteration

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,6 @@ pylibmc
 mysqlclient
 packaging
 requests
+fsspec
+h5py
+s3fs

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,10 @@ install_requires=[
     "packaging",
     "pymongo",
     "pylibmc",
-    "diskcache"
+    "diskcache",
+    "fsspec",
+    "h5py",
+    "s3fs"
     ]
 
 # get version string from __init__.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from hydra_base.lib.cache import clear_cache
 
 no_externaldb_opt = "--no-externaldb"
 externaldb_mark = "externaldb"
+requires_hdf_mark = "requires_hdf"
 
 def pytest_addoption(parser):
     parser.addoption("--db-backend", action="store", default="sqlite",
@@ -30,17 +31,30 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", f"{externaldb_mark}: Tests external storage")
+    config.addinivalue_line("markers", f"{requires_hdf_mark}: Indicates that decorated test requires HDF support")
 
 def pytest_collection_modifyitems(config, items):
     """
     When the `no_externaldb_opt` is present, add a skip mark to every
     test marked with `externaldb_mark`
+
+    When config has disabled HDF support, add a skip mark to every test
+    marked with `requires_hdf_mark`
     """
     if config.getoption(no_externaldb_opt):
         externaldb_skip = pytest.mark.skip(reason=f"{no_externaldb_opt} selected")
         for item in items:
             if externaldb_mark in item.keywords:
                 item.add_marker(externaldb_skip)
+
+    conf_disabled = hydra_base.config.CONFIG.get("storage_hdf", "disable_hdf").lower()
+    hdf_disabled = True if conf_disabled in ("true", "yes") else False
+    hdf_skip = pytest.mark.skip(reason="Test not applicable when HDF support disabled")
+    if hdf_disabled:
+        for item in items:
+            if requires_hdf_mark in item.keywords:
+                item.add_marker(hdf_skip)
+
 
 @pytest.fixture(scope="session")
 def db_backend(request):

--- a/tests/test_hdf.py
+++ b/tests/test_hdf.py
@@ -4,7 +4,6 @@ import pytest
 
 from packaging import version
 
-from hydra_base import config
 from hydra_base.lib import data
 from hydra_base.lib.storage import HdfStorageAdapter
 from hydra_base.util import NullAdapter
@@ -38,8 +37,6 @@ def aws_file():
 def bad_url(request):
     return request.param
 
-conf_disabled = config.CONFIG.get("storage_hdf", "disable_hdf").lower()
-hdf_disabled = True if conf_disabled in ("true", "yes") else False
 
 class TestHdf():
     def test_exists(self, hdf, hdf_config):
@@ -58,14 +55,14 @@ class TestHdf():
             lib = importlib.import_module(libname)
             assert version.parse(lib.__version__) >= semver
 
-    @pytest.mark.skipif(hdf_disabled, reason="Test not applicable when HDF support disabled")
+    @pytest.mark.requires_hdf
     def test_hdf_size(self, hdf, aws_file):
         """
           Does the reported file size match an expected value?
         """
         assert hdf.size(aws_file["path"]) == aws_file["file_size"]
 
-    @pytest.mark.skipif(hdf_disabled, reason="Test not applicable when HDF support disabled")
+    @pytest.mark.requires_hdf
     def test_hdf_info(self, hdf, aws_file):
         """
           Do the reported properties of a dataset match expected values?
@@ -76,7 +73,7 @@ class TestHdf():
         assert info["size"] == aws_file["dataset_size"]
         assert info["dtype"] == aws_file["dataset_type"]
 
-    @pytest.mark.skipif(hdf_disabled, reason="Test not applicable when HDF support disabled")
+    @pytest.mark.requires_hdf
     def test_hdf_dataset(self, hdf, aws_file):
         """
           Does a specified subset of a dataset match its expected
@@ -110,7 +107,7 @@ class TestHdf():
                 for ts, val in data.items():
                     assert np.isclose(df[dataset_name][ts], val)
 
-    @pytest.mark.skipif(hdf_disabled, reason="Test not applicable when HDF support disabled")
+    @pytest.mark.requires_hdf
     def test_hydra_hdf_size(self, aws_file):
         """
           Does the reported file size match an expected value when
@@ -118,7 +115,7 @@ class TestHdf():
         """
         assert data.get_hdf_filesize(aws_file["path"]) == aws_file["file_size"]
 
-    @pytest.mark.skipif(hdf_disabled, reason="Test not applicable when HDF support disabled")
+    @pytest.mark.requires_hdf
     def test_hydra_hdf_info(self, aws_file):
         """
           Do the reported properties of a dataset match expected values when
@@ -130,7 +127,7 @@ class TestHdf():
         assert info["size"] == aws_file["dataset_size"]
         assert info["dtype"] == aws_file["dataset_type"]
 
-    @pytest.mark.skipif(hdf_disabled, reason="Test not applicable when HDF support disabled")
+    @pytest.mark.requires_hdf
     def test_hydra_hdf_dataset(self, aws_file):
         """
           Does a specified subset of a dataset match its expected
@@ -164,7 +161,7 @@ class TestHdf():
                 for ts, val in series.items():
                     assert np.isclose(df[dataset_name][ts], val)
 
-    @pytest.mark.skipif(hdf_disabled, reason="Test not applicable when HDF support disabled")
+    @pytest.mark.requires_hdf
     def test_bad_url(self, bad_url):
         """
           Does an inaccessible url raise ValueError?
@@ -172,7 +169,7 @@ class TestHdf():
         with pytest.raises(ValueError):
             info = data.get_hdf_dataset_info(bad_url, "dataset_name")
 
-    @pytest.mark.skipif(hdf_disabled, reason="Test not applicable when HDF support disabled")
+    @pytest.mark.requires_hdf
     def test_bad_dataset_name(self, aws_file):
         """
           Does a nonexistent dataset name raise ValueError both for
@@ -184,7 +181,7 @@ class TestHdf():
         with pytest.raises(ValueError):
             df_json = data.get_hdf_dataframe(aws_file["path"], "nonexistent_dataset", 8, 16)
 
-    @pytest.mark.skipif(hdf_disabled, reason="Test not applicable when HDF support disabled")
+    @pytest.mark.requires_hdf
     def test_bad_bounds(self, aws_file):
         """
           Do invalid bounds (start<0, start>end, end<0, end>size) raise ValueError?
@@ -201,7 +198,7 @@ class TestHdf():
         with pytest.raises(ValueError):
             df_json = data.get_hdf_dataframe(aws_file["path"], aws_file["dataset_name"], 8, 1e72)
 
-    @pytest.mark.skipif(hdf_disabled, reason="Test not applicable when HDF support disabled")
+    @pytest.mark.requires_hdf
     def test_bad_url_does_not_exist(self, bad_url):
         """
           Does data.file_exists_at_url() return False for nonexistent
@@ -209,7 +206,7 @@ class TestHdf():
         """
         assert not data.file_exists_at_url(bad_url)
 
-    @pytest.mark.skipif(hdf_disabled, reason="Test not applicable when HDF support disabled")
+    @pytest.mark.requires_hdf
     def test_existing_file_at_url_exists(self, aws_file):
         """
           Does data.file_exists_at_url() return True for existing
@@ -226,11 +223,13 @@ class TestHdf():
         NullAdapter.method()
         NullAdapter.nested.method()
 
+        # Instance method
         na = NullAdapter()
         na.do.nothing()
 
-        # Is iterable
+        # Is iterable?
         for i in na:
             pass
 
+        # Is subscriptable?
         assert na[2] == None

--- a/tests/test_hdf.py
+++ b/tests/test_hdf.py
@@ -1,0 +1,35 @@
+import json
+import pytest
+import random
+
+from packaging import version
+
+import hydra_base
+from hydra_base.lib.storage import HdfStorageAdapter
+
+min_lib_versions = {
+    "fsspec": version.parse("0.9.0"),
+    "h5py": version.parse("3.7.0"),
+    "s3fs": version.parse("0.6.0")
+}
+
+@pytest.fixture
+def hdf():
+    hdf = HdfStorageAdapter()
+    return hdf
+
+@pytest.fixture
+def hdf_config():
+    return HdfStorageAdapter.get_hdf_config()
+
+
+class TestHdf():
+    def test_exists(self, hdf, hdf_config):
+        assert hdf
+        assert hdf_config
+
+    def test_lib_versions(self):
+        import importlib
+        for libname, semver in min_lib_versions.items():
+            lib = importlib.import_module(libname)
+            assert version.parse(lib.__version__) >= semver

--- a/tests/test_hdf.py
+++ b/tests/test_hdf.py
@@ -115,7 +115,7 @@ class TestHdf():
           Do the reported properties of a dataset match expected values when
           accessed via hydra.lib?
         """
-        info = data.get_hdf_info(aws_file["path"], aws_file["dataset_name"])
+        info = data.get_hdf_dataset_info(aws_file["path"], aws_file["dataset_name"])
 
         assert info["name"] == aws_file["dataset_name"]
         assert info["size"] == aws_file["dataset_size"]
@@ -159,7 +159,7 @@ class TestHdf():
           Does an inaccessible url raise ValueError?
         """
         with pytest.raises(ValueError):
-            info = data.get_hdf_info(bad_url, "dataset_name")
+            info = data.get_hdf_dataset_info(bad_url, "dataset_name")
 
     def test_bad_dataset_name(self, aws_file):
         """
@@ -167,14 +167,14 @@ class TestHdf():
           info and series retrieval?
         """
         with pytest.raises(ValueError):
-            info = data.get_hdf_info(aws_file["path"], "nonexistent_dataset")
+            info = data.get_hdf_dataset_info(aws_file["path"], "nonexistent_dataset")
 
         with pytest.raises(ValueError):
             df_json = data.get_hdf_dataframe(aws_file["path"], "nonexistent_dataset", 8, 16)
 
     def test_bad_bounds(self, aws_file):
         """
-           Do invalid bounds (start<0, start>end, end<0, end>size) raise ValueError?
+          Do invalid bounds (start<0, start>end, end<0, end>size) raise ValueError?
         """
         with pytest.raises(ValueError):
             df_json = data.get_hdf_dataframe(aws_file["path"], aws_file["dataset_name"], -1, 16)
@@ -187,3 +187,17 @@ class TestHdf():
 
         with pytest.raises(ValueError):
             df_json = data.get_hdf_dataframe(aws_file["path"], aws_file["dataset_name"], 8, 1e72)
+
+    def test_bad_url_does_not_exist(self, bad_url):
+        """
+          Does data.file_exists_at_url() return False for nonexistent
+          files on remote or local filesystem?
+        """
+        assert not data.file_exists_at_url(bad_url)
+
+    def test_existing_file_at_url_exists(self, aws_file):
+        """
+          Does data.file_exists_at_url() return True for existing
+          files on remote or local filesystem?
+        """
+        assert data.file_exists_at_url(aws_file["path"])

--- a/tests/test_hdf.py
+++ b/tests/test_hdf.py
@@ -1,4 +1,6 @@
 import json
+import numpy as np
+import pandas as pd
 import pytest
 import random
 
@@ -22,14 +24,79 @@ def hdf():
 def hdf_config():
     return HdfStorageAdapter.get_hdf_config()
 
+@pytest.fixture
+def aws_file():
+    return {
+        "path": "s3://modelers-data-bucket/eapp/single/ETH_flow_sim.h5",
+        "file_size": 7374454,
+        "dataset_name": "BR_Kabura",
+        "dataset_size": 12784,
+        "dataset_type": "float64"
+    }
+
 
 class TestHdf():
     def test_exists(self, hdf, hdf_config):
+        """
+          Can the HDF adapter be instantiated, and does the config exist?
+        """
         assert hdf
         assert hdf_config
 
     def test_lib_versions(self):
+        """
+          Are the required libraries present and adequate versions?
+        """
         import importlib
         for libname, semver in min_lib_versions.items():
             lib = importlib.import_module(libname)
             assert version.parse(lib.__version__) >= semver
+
+    def test_hdf_size(self, hdf, aws_file):
+        """
+          Does the reported file size match an expected value?
+        """
+        assert hdf.size(aws_file["path"]) == aws_file["file_size"]
+
+    def test_hdf_info(self, hdf, aws_file):
+        """
+          Do the reported properties of a dataset match expected values?
+        """
+        info = hdf.get_dataset_info_url(aws_file["path"], aws_file["dataset_name"])
+
+        assert info["name"] == aws_file["dataset_name"]
+        assert info["size"] == aws_file["dataset_size"]
+        assert info["dtype"] == aws_file["dataset_type"]
+
+    def test_hdf_dataset(self, hdf, aws_file):
+        """
+          Does a specified subset of a dataset match its expected
+          index and series values?
+        """
+        expected = {
+            aws_file["dataset_name"]: {
+                (8,16): { "1972-01-09": 0.65664,
+                          "1972-01-10": 0.65664,
+                          "1972-01-11": 0.65664,
+                          "1972-01-12": 0.65664,
+                          "1972-01-13": 0.65664,
+                          "1972-01-14": 0.65664,
+                          "1972-01-15": 0.65664,
+                          "1972-01-16": 0.65664},
+
+                (12008,12016): { "2004-11-16": 1.2528,
+                                 "2004-11-17": 1.2528,
+                                 "2004-11-18": 1.2528,
+                                 "2004-11-19": 1.2528,
+                                 "2004-11-20": 1.2528,
+                                 "2004-11-21": 1.2528,
+                                 "2004-11-22": 1.2528,
+                                 "2004-11-23": 1.2528}
+            }
+        }
+        for dataset_name, ranges in expected.items():
+            for bounds, data in ranges.items():
+                df_json = hdf.hdf_dataset_to_pandas_dataframe(aws_file["path"], dataset_name, *bounds)
+                df = pd.read_json(df_json)
+                for ts, val in data.items():
+                    assert np.isclose(df[dataset_name][ts], val)


### PR DESCRIPTION
Closes #164

* Adds api to query HDf files in local and remote storage, describe datasets, and retrieve segments of datasets.
* Allows rewriting of urls to a local filestore
* Adds `hydra.ini` config to disable HDF support
* Adds some utility functions to test existence of files at urls and total filesize
* Adds tests