### PR TITLE
168 extend hdf storage interface to allow partial reads

### DIFF
--- a/hydra_base/lib/data.py
+++ b/hydra_base/lib/data.py
@@ -1130,10 +1130,31 @@ def get_hdf_series_info(url, groupname=None, columns=None, **kwargs):
     return hdf.get_series_info(url, groupname, columns)
 
 def get_hdf_index_info(url, groupname, **kwargs):
+    """
+      Returns an object with keys...
+        {name: str, length: int, dtype: str}
+      ...which describes the index of the <groupname> argument.
+    """
     hdf = HdfStorageAdapter()
     return hdf.get_index_info(url, groupname)
 
+def get_hdf_index_range(url, groupname, start=0, end=None, **kwargs):
+    """
+      Returns index entries in the range [start,end) of the <groupname>
+      argument.
+    """
+    hdf = HdfStorageAdapter()
+    return hdf.get_index_range(url, groupname, start, end)
+
 def get_hdf_group_info(url, groupname=None, **kwargs):
+    """
+      Returns an object containing two keys:
+        - index: an object of 'name', 'length', 'dtype' for
+                 the index of the <group> arg
+        - series: an array of objects, each containing 'name',
+                  'length', 'dtype' for each column of the
+                  <group> arg
+    """
     hdf = HdfStorageAdapter()
     return hdf.get_group_info(url, groupname)
 

--- a/hydra_base/lib/data.py
+++ b/hydra_base/lib/data.py
@@ -41,6 +41,7 @@ from ..db.model import Dataset, Metadata, DatasetOwner, DatasetCollection,\
 from ..exceptions import HydraError, PermissionError, ResourceNotFoundError
 from ..util import generate_data_hash
 from ..util.hydra_dateutil import get_datetime
+from ..util.permissions import required_role
 
 from hydra_base.lib.storage import (
     MongoStorageAdapter,
@@ -1174,8 +1175,7 @@ def file_exists_at_url(url, **kwargs):
 def get_hdf_group_as_dataframe(url, **kwargs):
     """
       Return the entire table of series within an HDF group as a
-      single dataframe.
-      Timeseries indices are represented in iso8601 format
+      single dataframe.  Timeseries indices are represented in iso8601 format
       Keyword arguments:
         <groupname> if absent assume file contains a single group
         <start> start group row, 0 if absent
@@ -1201,6 +1201,7 @@ def get_hdf_group_columns(url, groupname, **kwargs):
     hdf = HdfStorageAdapter()
     return hdf.get_group_columns(url, groupname)
 
+@required_role("admin")
 def retrieve_s3_file_to_local_storage(url, **kwargs):
     """
       Forces retrieval of the s3 file at <url> to Hydra's
@@ -1211,3 +1212,23 @@ def retrieve_s3_file_to_local_storage(url, **kwargs):
     hdf = HdfStorageAdapter()
     file_path, file_size = hdf.retrieve_s3_file(url)
     return file_path, file_size
+
+@required_role("admin")
+def list_local_files(**kwargs):
+    """
+      Returns an object of filename: file_size mappings
+      describing files in the HDF filestore
+    """
+    hdf = HdfStorageAdapter()
+    return hdf.list_local_files()
+
+@required_role("admin")
+def purge_local_file(filename, **kwargs):
+    """
+      Removes a file from the HDF filestore.
+      Returns the path of the deleted filename on
+      success.
+      Raises ValueError on failure.
+    """
+    hdf = HdfStorageAdapter()
+    return hdf.purge_local_file(filename)

--- a/hydra_base/lib/data.py
+++ b/hydra_base/lib/data.py
@@ -1117,7 +1117,7 @@ def get_hdf_dataset_info(url, dataset_name, **kwargs):
     hdf = HdfStorageAdapter()
     return hdf.get_dataset_info_url(url, dataset_name)
 
-def get_hdf_dataframe(url, dataset_name, start, end, **kwargs):
+def get_columns_as_dataframe(url, groupname, columns, start, end, **kwargs):
     """
       Returns the rows from <start> to <end> of <dataset_name> in
       the hdf file <url> as the json representation of a Pandas
@@ -1126,7 +1126,7 @@ def get_hdf_dataframe(url, dataset_name, start, end, **kwargs):
       Raises ValueError on bad url, dataset name or bounds
     """
     hdf = HdfStorageAdapter()
-    return hdf.hdf_dataset_to_pandas_dataframe(url, dataset_name, start, end, **kwargs)
+    return hdf.get_columns_as_dataframe(url, groupname, columns, start, end)
 
 def resolve_url_to_path(url, **kwargs):
     """

--- a/hydra_base/lib/storage/hdfstorageadapter.py
+++ b/hydra_base/lib/storage/hdfstorageadapter.py
@@ -2,6 +2,7 @@ import fsspec
 import h5py
 import inspect
 import logging
+import numpy as np
 import os
 import pandas as pd
 import s3fs
@@ -290,6 +291,143 @@ class HdfStorageAdapter():
         log.info(f"Retrieved {destfile} ({file_sz} bytes)")
         return destfile, file_sz
 
+    """
+      pandas_type == "frame_table" support
+    """
+
+    def identify_group_format(self, url, groupname):
+        hf = self.open_hdf_url(url)
+        try:
+            group = hf[groupname]
+        except KeyError as ke:
+            raise ValueError(f"Error: file at {url} contains no group {groupname}") from ke
+
+        try:
+            pandas_type = group.attrs["pandas_type"]
+        except KeyError as ke:
+            raise ValueError(f"Error: file at {url} has invalid format") from ke
+
+        return pandas_type.decode()
+
+
+class FrameGroupReader():
+    pass
+
+class FrameTableGroupReader():
+    def __init__(self, hf, groupname):
+        self.hf = hf
+        try:
+            self.group = hf[groupname]
+        except KeyError as ke:
+            raise ValueError(f"Error: file {hf.filename} contains no group {groupname}") from ke
+        try:
+            self.table = self.group["table"]
+        except KeyError as ke:
+            raise ValueError(f"Error: file {hf.filename} has invalid format, no 'table'") from ke
+
+    def get_index_column_index(self):
+        max_index_depth = 128
+        try:
+            index_cols_raw = self.group.attrs["index_cols"].decode().split('\n')[2:-2:2]
+        except KeyError:
+            # No index columns present
+            return None
+        index_cols = trim_x_first_y_rest(1, 2, index_cols_raw)
+        index_name = index_cols[0]  # Assume single index
+
+        for field_idx in range(max_index_depth):
+            try:
+                field_name = self.table.attrs[f"FIELD_{field_idx}_NAME"]
+            except KeyError:
+                # No field has the name of the stated index column
+                return None
+            if field_name.decode() == index_name:
+                return field_idx
+
+    def get_values_start_block_index(self):
+        max_value_depth = 128
+        try:
+            value_cols_raw = self.group.attrs["values_cols"].decode().split('\n')[1:-1:2]
+        except KeyError:
+            # Group contains no value columns
+            return None
+        value_cols = trim_x_first_y_rest(1, 2, value_cols_raw)
+        first_value_col = value_cols[0]
+
+        for field_idx in range(max_value_depth):
+            try:
+                field_name = self.table.attrs[f"FIELD_{field_idx}_NAME"]
+            except KeyError:
+                # No more fields
+                return None
+            if field_name.decode() == first_value_col:
+                return field_idx
+
+    def get_index_range(self, start=None, end=None):
+        start = start or 0
+        end = end or len(table)
+
+        index_idx = self.get_index_column_index()
+        if index_idx is None:
+            return []
+        return [nscale(row[index_idx]) for row in self.table[start:end]]
+
+    def get_columns_by_block(self):
+        value_cols_raw = self.group.attrs["values_cols"].decode().split('\n')[1:-1:2]
+        value_cols = trim_x_first_y_rest(1, 2, value_cols_raw)
+
+        block_columns = []
+        for field_idx, field_name in enumerate(value_cols, start=1):
+            kind = self.table.attrs[f"{field_name}_kind"]
+            kind_cols_raw = kind.decode().split('\n')[1:-1:2]
+            kind_cols = trim_x_first_y_rest(1, 2, kind_cols_raw)
+            block_columns.append(kind_cols)
+
+        return block_columns
+
+    def get_series_by_column_names(self, column_names, start=None, end=None):
+        columns = self.get_columns_of_group()
+        block_columns = self.get_columns_by_block()
+        attr_columns = [{"columns": block} for block in block_columns]
+
+        column_map = self.make_column_map_of_group(attr_columns)
+        named_map = {cname: cmap for cname, cmap in zip(columns, column_map)}
+
+        first_value_block_idx = self.get_values_start_block_index()
+
+        start = start or 0
+        end = end or len(table)
+        column_series = {}
+        for column_name in column_names:
+            block_idx, col_idx = named_map[column_name]
+            block_rows = np.array([row[block_idx+first_value_block_idx] for row in self.table[start:end]])
+            section = block_rows[:, col_idx]
+            column_series[column_name] = section
+
+        return column_series
+
+    def get_columns_as_dataframe(self, columns, start=None, end=None):
+        index_range = self.get_index_range(start, end)
+        column_series = self.get_series_by_column_names(columns, start, end)
+        return make_pandas_dataframe(index_range, column_series)
+
+    def make_column_map_of_group(self, blocks):
+        non_index_cols = self.get_columns_of_group()
+        return [column_to_block_coord(column, blocks) for column in non_index_cols]
+
+    def get_columns_of_group(self):
+        non_index_cols_raw = self.group.attrs["non_index_axes"].decode().split("\n")[3:-3:2]
+        return trim_x_first_y_rest(1, 2, non_index_cols_raw)
+
+    def get_group_shape(self):
+        row_sz = len(self.table)
+        col_sz = len(self.get_columns_of_group())
+        return (row_sz, col_sz)
+
+
+"""
+  Auxiliary Functions
+"""
 
 def nscale(ts):
     """
@@ -298,6 +436,24 @@ def nscale(ts):
     """
     return datetime.fromtimestamp(ts/1e9)
 
+def trim_x_first_y_rest(x, y, names):
+    return [names[0][x:], *[name[y:] for name in names[1:]] ]
+
+def column_to_block_coord(column, blocks):
+    for block_idx, block in enumerate(blocks):
+        try:
+            col_idx = block["columns"].index(column)
+        except ValueError:
+            continue
+        return (block_idx, col_idx)
+    raise ValueError(f"Column {column} not found in any block")
+
+def make_pandas_dataframe(index, series):
+    return pd.DataFrame(
+        {name: values for name, values in series.items()},
+        index=pd.DatetimeIndex(index)
+    )
+
 
 """
   If config defines [hdf_storage]::disable_hdf as "True",
@@ -305,3 +461,21 @@ def nscale(ts):
 """
 if HdfStorageAdapter.get_hdf_config().get("disable_hdf"):
     HdfStorageAdapter = NullAdapter
+
+
+if __name__ == "__main__":
+    filepath = "grid_data.h5"
+    groupname = "central_south_essex_results"
+    #groupname = "ESW_Essex_results"
+    #groupname = "daily_profiles"
+    hsa = HdfStorageAdapter()
+
+    pt = hsa.identify_group_format(filepath, groupname)
+    if pt == "frame_table":
+        hf = hsa.open_hdf_url(filepath)
+        reader = FrameTableGroupReader(hf, groupname)
+        gc = reader.get_columns_of_group()
+        df = reader.get_columns_as_dataframe(gc[:4], start=2, end=10)
+    elif pt == "frame":
+        pass
+    breakpoint()

--- a/hydra_base/lib/storage/hdfstorageadapter.py
+++ b/hydra_base/lib/storage/hdfstorageadapter.py
@@ -252,6 +252,7 @@ class HdfStorageAdapter():
             - undefined
             - the root filesystem
             - the root of any mount point
+
           ValueError is raised if any of these conditions
           are not met.
         """
@@ -278,8 +279,8 @@ class HdfStorageAdapter():
                              f"user {os.getlogin()} ({os.getuid()})")
         try:
             os.unlink(target)
-        except OSError:
-            raise ValueError(f"Invalid path '{filename}': Unable to purge file")
+        except OSError as oe:
+            raise ValueError(f"Invalid path '{filename}': Unable to purge file") from oe
 
         return target
 

--- a/hydra_base/lib/storage/hdfstorageadapter.py
+++ b/hydra_base/lib/storage/hdfstorageadapter.py
@@ -290,6 +290,12 @@ class HdfStorageAdapter():
         return target
 
     def make_group_reader(self, url, groupname):
+        """
+        Returns an instance of the appropriate GroupReader subclass for the <groupname>
+        argument in the file at <url>.
+        The required type is first looked up by get_group_reader() and an instance of
+        this is returned.
+        """
         hf = self.open_hdf_url(url)
         if not groupname:
             # Use first group in file
@@ -301,6 +307,13 @@ class HdfStorageAdapter():
         return Reader(hf, groupname)
 
     def get_group_reader(self, url, groupname):
+        """
+        Returns the type of the appropriate GroupReader subclass for the <groupname>
+        argument in the file at <url>.
+        The internal format of the group used by Pandas is first identified by
+        identify_group_format(), and a reader capable of handling this type is then
+        looked up in the group_reader_map.
+        """
         group_type = self.identify_group_format(url, groupname)
         try:
             Reader = group_reader_map[group_type]
@@ -311,6 +324,13 @@ class HdfStorageAdapter():
         return Reader
 
     def identify_group_format(self, url, groupname):
+        """
+        Returns a string identifying the Pandas format of the group <groupname> in
+        the file at <url>.
+        This string, stored as the `pandas_type` attribute on the HDF group, indicates
+        the layout of datasets and indices for the group and therefore the type of
+        GroupReader required.
+        """
         hf = self.open_hdf_url(url)
         try:
             group = hf[groupname]

--- a/hydra_base/lib/storage/hdfstorageadapter.py
+++ b/hydra_base/lib/storage/hdfstorageadapter.py
@@ -15,6 +15,11 @@ from functools import wraps
 from hydra_base import config
 from hydra_base.util import NullAdapter
 
+from hydra_base.lib.storage.readers import (
+    FrameGroupReader,
+    FrameTableGroupReader
+)
+
 log = logging.getLogger(__name__)
 
 
@@ -53,6 +58,11 @@ class HdfStorageAdapter():
     """
        Utilities to describe and retrieve data from HDF storage
     """
+
+    group_readers = {
+        "frame": FrameGroupReader,
+        "frame_table": FrameTableGroupReader
+    }
 
     def __init__(self):
         self.config = self.__class__.get_hdf_config()
@@ -103,9 +113,13 @@ class HdfStorageAdapter():
         except (ValueError, FileNotFoundError, PermissionError):
             return False
 
-
-    @filestore_url("filepath")
-    def get_dataset_info_file(self, filepath, dsname, **kwargs):
+    #@filestore_url("filepath")
+    #def get_dataset_info_file(self, filepath, dsname, **kwargs):
+    @filestore_url("url")
+    def get_group_info_file(self, url, group, **kwargs):
+        """
+          Todo rewrite with no pandas.read_hdf
+        """
         df = pd.read_hdf(filepath)
         series = df[dsname]
         index = df.index
@@ -121,18 +135,6 @@ class HdfStorageAdapter():
         }
         return info
 
-    @filestore_url("filepath")
-    def get_dataset_block_file(self, filepath, dsname, start, end, **kwargs):
-        df = pd.read_hdf(filepath)
-        section = df[dsname][start:end]
-        block_index = section.index.map(str).tolist()
-        block_values = section.values.tolist()
-
-        return {
-            "index": block_index,
-            "series": block_values
-        }
-
     @filestore_url("url")
     def size(self, url, **kwargs):
         with fsspec.open(url, mode='rb', anon=True, default_fill_cache=False) as fp:
@@ -140,116 +142,46 @@ class HdfStorageAdapter():
 
         return size_bytes
 
+    @filestore_url("url")
     def get_hdf_groups(self, url, **kwargs):
         h5f = self.open_hdf_url(url)
         return [*h5f.keys()]
 
+    @filestore_url("url")
     def get_group_columns(self, url, groupname, **kwargs):
         h5f = self.open_hdf_url(url)
         try:
             group = h5f[groupname]
         except KeyError as ke:
             raise ValueError(f"Data source {url} does not contain specified group: {groupname}") from ke
+        # todo
 
-        localpath, filename = self.equivalent_local_path(url)
-        localfile = os.path.join(localpath, filename)
-        if not os.path.exists(localfile):
-            self.retrieve_s3_file(url)
-        df = pd.read_hdf(localfile, key=groupname)
-        return df.columns.to_list()
-
-    def hdf_group_to_pandas_dataframe(self, url, groupname=None, series=None, as_json=True, **kwargs):
+    def hdf_get_columns_as_dataframe(self, url, groupname=None, columns=None, start, end, **kwargs):
         json_opts = {"date_format": "iso"}
+        hf = self.open_hdf_url(url)
 
-        localpath, filename = self.equivalent_local_path(url)
-        localfile = os.path.join(localpath, filename)
-        if not os.path.exists(localfile):
-            self.retrieve_s3_file(url)
-        df = pd.read_hdf(localfile, key=groupname)  # pd uses key=None as equivalent to no kwarg
-        if series:
-            if as_json:
-                return df[series].to_json(**json_opts)
-            else:
-                return df[series]
-        if as_json:
-            return df.to_json(**json_opts)
-        else:
-            return df
-
-    def hdf_dataset_to_pandas_dataframe(self, url, dsname, start, end, groupname=None, **kwargs):
-        json_opts = {"date_format": "iso"}
-        h5f = self.open_hdf_url(url)
-        """
-          Pywr uses hdf group names implicitly and these vary by dataset type.
-          Assume the first key of the hdf doc represents a group containing
-          the [axis0, axis1, block0_index, block0_values] constituents of a
-          Pandas dataframe.
-          Alternately, a groupname may be specified for cases where a data
-          source contains multiple groups.
-        """
         if not groupname:
             try:
-                groupname = [*h5f.keys()][0]
+                groupname = [*hf.keys()][0]
             except IndexError as ie:
                 raise ValueError(f"Data source {url} contains no groups") from ie
         try:
-            group = h5f[groupname]
+            group = hf[groupname]
         except KeyError as ke:
             raise ValueError(f"Data source {url} does not contain specified group: {groupname}") from ke
-        try:
-            bcols = group["axis0"][:]
-        except KeyError as ke:
-            try:
-                df = self.hdf_group_to_pandas_dataframe(url, groupname=groupname, series=dsname, as_json=False)
-                return df[start:end].to_json(**json_opts)
-            except:
-                pass
-            raise ValueError(f"Data source {url} has invalid structure") from ke
 
-        cols = [*map(bytes.decode, bcols)]
+        if not columns:
+            columns = reader.get_columns_of_group()
 
-        try:
-            series_col = cols.index(dsname)
-        except ValueError as ve:
-            raise ValueError(f"No series '{dsname}' in {url}") from ve
+        reader = self.make_reader(url, groupname)
+        df = reader.get_columns_as_dataframe(columns, start=start, end=end)
 
-        val_ds = group["block0_values"]
-        val_rows = val_ds.shape[0]
-
-        if start < 0 or start >= val_rows or start >= end or end < 0 or end >= val_rows:
-            raise ValueError(f"Invalid section in dataset of size {val_rows}: {start=}, {end=}")
-
-        val_sect = val_ds[start:end]
-        section = [ i[0] for i in val_sect[:, series_col:series_col+1].tolist() ]
-
-        ts_nano = group["axis1"][start:end]
-        ts_sec = [*map(nscale, ts_nano)]
-        timestamps = [*map(str, ts_sec)]
-
-        h5f.close()
-
-        df = pd.DataFrame({dsname: section}, index=pd.DatetimeIndex(timestamps))
         return df.to_json(**json_opts)
 
     def get_dataset_info_url(self, url, dsname, **kwargs):
-        h5f = self.open_hdf_url(url)
-
-        groupname = [*h5f.keys()][0]
-        try:
-            group = h5f[groupname]
-            bcols = group["axis0"][:]
-        except KeyError as ke:
-            raise ValueError(f"Data source {url} has invalid structure") from ke
-
-        cols = [*map(bytes.decode, bcols)]
-
-        try:
-            _ = cols.index(dsname)
-        except ValueError as ve:
-            raise ValueError(f"No series '{dsname}' in {url}") from ve
-
-        val_ds = group["block0_values"]
-        val_rows = val_ds.shape[0]
+        """
+          Todo: preserve return
+        """
 
         return {
             "name": dsname,
@@ -270,6 +202,10 @@ class HdfStorageAdapter():
             destdir = filedir
         return destdir, os.path.basename(filesrc)
 
+    """
+      Make this explicitly callable to force file
+      to local cache at user's discretion
+    """
     def retrieve_s3_file(self, url, **kwargs):
         u = urlparse(url)
         if not u.scheme == "s3":
@@ -291,6 +227,21 @@ class HdfStorageAdapter():
         log.info(f"Retrieved {destfile} ({file_sz} bytes)")
         return destfile, file_sz
 
+    def make_reader(self, url, groupname):
+        Reader = self.get_group_reader(url, groupname)
+        hf = self.open_hdf_url(url)
+
+        return Reader(hf, groupname)
+
+    def get_group_reader(self, url, groupname):
+        group_type = self.identify_group_format(url, groupname)
+        try:
+            Reader = self.__class__.group_readers[group_type]
+        except KeyError:
+            # Not-None group_type was returned, but we don't have a reader for it
+            raise ValueError(f"Error: No reader available for group of type {group_type}")
+
+        return Reader
 
     def identify_group_format(self, url, groupname):
         hf = self.open_hdf_url(url)
@@ -305,232 +256,6 @@ class HdfStorageAdapter():
             raise ValueError(f"Error: file at {url} has invalid format") from ke
 
         return pandas_type.decode()
-
-
-class FrameGroupReader():
-    """
-      pandas_type == "frame"
-    """
-    def __init__(self, hf, groupname):
-        self.hf = hf
-        try:
-            self.group = hf[groupname]
-        except KeyError as ke:
-            raise ValueError(f"Error: file {hf.filename} contains no group {groupname}") from ke
-
-    def get_columns_of_group(self):
-        try:
-            columns_raw = [*self.group["axis0"]]
-        except KeyError as ke:
-            raise ValueError(f"Error: {self.group.name} has invalid format") from ke
-        return [col.decode() for col in columns_raw]
-
-    def get_columns_by_block(self):
-        try:
-            nblocks = self.group.attrs["nblocks"]
-        except KeyError as ke:
-            raise KeyError(f"Error: group {self.group.name} contains no blocks") from ke
-        blocks_columns = []
-        for block_idx in range(nblocks):
-            columns_raw = [*self.group[f"block{block_idx}_items"]]
-            blocks_columns.append([col.decode() for col in columns_raw])
-        return blocks_columns
-
-    def make_column_map_of_group(self, blocks):
-        group_cols = self.get_columns_of_group()
-        return [column_to_block_coord(column, blocks) for column in group_cols]
-
-    def get_series_by_column_names(self, column_names, start=None, end=None):
-        columns = self.get_columns_of_group()
-        block_columns = self.get_columns_by_block()
-
-        column_map = self.make_column_map_of_group(block_columns)
-        named_map = {cname: cmap for cname, cmap in zip(columns, column_map)}
-
-        start = start or 0
-        end = end or len(table)
-        column_series = {}
-        for column_name in column_names:
-            block_idx, col_idx = named_map[column_name]
-            block_values_name = f"block{block_idx}_values"
-            block_values = self.group[block_values_name]
-            section = np.array([row[col_idx] for row in block_values[start:end]])
-            column_series[column_name] = section
-
-        return column_series
-
-    def find_index_axis_index(self):
-        for ent in self.group:
-            try:
-                index_class = self.group[ent].attrs["index_class"]
-                return ent
-            except KeyError:
-                continue
-
-        raise ValueError(f"Group {self.group.name} of pandas_type "
-                          "'frame' contains no index axis")
-
-    def get_index_range(self, start=None, end=None):
-        start = start or 0
-        end = end or len(table)
-
-        index_axis = self.find_index_axis_index()
-        index = self.group[index_axis]
-        return [nscale(row) for row in index[start:end]]
-
-    def get_columns_as_dataframe(self, columns, start=None, end=None):
-        index_range = self.get_index_range(start, end)
-        column_series = self.get_series_by_column_names(columns, start, end)
-        return make_pandas_dataframe(index_range, column_series)
-
-    def get_group_shape(self):
-        row_sz = len(self.group["axis1"])
-        col_sz = len(self.get_columns_of_group())
-        return (row_sz, col_sz)
-
-
-class FrameTableGroupReader():
-    """
-      pandas_type == "frame_table"
-    """
-    def __init__(self, hf, groupname):
-        self.hf = hf
-        try:
-            self.group = hf[groupname]
-        except KeyError as ke:
-            raise ValueError(f"Error: file {hf.filename} contains no group {groupname}") from ke
-        try:
-            self.table = self.group["table"]
-        except KeyError as ke:
-            raise ValueError(f"Error: file {hf.filename} has invalid format, no 'table'") from ke
-
-    def get_index_column_index(self):
-        max_index_depth = 128
-        try:
-            index_cols_raw = self.group.attrs["index_cols"].decode().split('\n')[2:-2:2]
-        except KeyError:
-            # No index columns present
-            return None
-        index_cols = trim_x_first_y_rest(1, 2, index_cols_raw)
-        index_name = index_cols[0]  # Assume single index
-
-        for field_idx in range(max_index_depth):
-            try:
-                field_name = self.table.attrs[f"FIELD_{field_idx}_NAME"]
-            except KeyError:
-                # No field has the name of the stated index column
-                return None
-            if field_name.decode() == index_name:
-                return field_idx
-
-    def get_values_start_block_index(self):
-        max_value_depth = 128
-        try:
-            value_cols_raw = self.group.attrs["values_cols"].decode().split('\n')[1:-1:2]
-        except KeyError:
-            # Group contains no value columns
-            return None
-        value_cols = trim_x_first_y_rest(1, 2, value_cols_raw)
-        first_value_col = value_cols[0]
-
-        for field_idx in range(max_value_depth):
-            try:
-                field_name = self.table.attrs[f"FIELD_{field_idx}_NAME"]
-            except KeyError:
-                # No more fields
-                return None
-            if field_name.decode() == first_value_col:
-                return field_idx
-
-    def get_index_range(self, start=None, end=None):
-        start = start or 0
-        end = end or len(table)
-
-        index_idx = self.get_index_column_index()
-        if index_idx is None:
-            return []
-        return [nscale(row[index_idx]) for row in self.table[start:end]]
-
-    def get_columns_by_block(self):
-        value_cols_raw = self.group.attrs["values_cols"].decode().split('\n')[1:-1:2]
-        value_cols = trim_x_first_y_rest(1, 2, value_cols_raw)
-
-        block_columns = []
-        for field_idx, field_name in enumerate(value_cols, start=1):
-            kind = self.table.attrs[f"{field_name}_kind"]
-            kind_cols_raw = kind.decode().split('\n')[1:-1:2]
-            kind_cols = trim_x_first_y_rest(1, 2, kind_cols_raw)
-            block_columns.append(kind_cols)
-
-        return block_columns
-
-    def get_series_by_column_names(self, column_names, start=None, end=None):
-        columns = self.get_columns_of_group()
-        block_columns = self.get_columns_by_block()
-
-        column_map = self.make_column_map_of_group(block_columns)
-        named_map = {cname: cmap for cname, cmap in zip(columns, column_map)}
-
-        first_value_block_idx = self.get_values_start_block_index()
-
-        start = start or 0
-        end = end or len(table)
-        column_series = {}
-        for column_name in column_names:
-            block_idx, col_idx = named_map[column_name]
-            block_rows = np.array([row[block_idx+first_value_block_idx] for row in self.table[start:end]])
-            section = block_rows[:, col_idx]
-            column_series[column_name] = section
-
-        return column_series
-
-    def get_columns_as_dataframe(self, columns, start=None, end=None):
-        index_range = self.get_index_range(start, end)
-        column_series = self.get_series_by_column_names(columns, start, end)
-        return make_pandas_dataframe(index_range, column_series)
-
-    def make_column_map_of_group(self, blocks):
-        non_index_cols = self.get_columns_of_group()
-        return [column_to_block_coord(column, blocks) for column in non_index_cols]
-
-    def get_columns_of_group(self):
-        non_index_cols_raw = self.group.attrs["non_index_axes"].decode().split("\n")[3:-3:2]
-        return trim_x_first_y_rest(1, 2, non_index_cols_raw)
-
-    def get_group_shape(self):
-        row_sz = len(self.table)
-        col_sz = len(self.get_columns_of_group())
-        return (row_sz, col_sz)
-
-
-"""
-  Auxiliary Functions
-"""
-
-def nscale(ts):
-    """
-      Transforms integers representing nanoseconds past the epoch
-      into instances of datetime.timestamp
-    """
-    return datetime.fromtimestamp(ts/1e9)
-
-def trim_x_first_y_rest(x, y, names):
-    return [names[0][x:], *[name[y:] for name in names[1:]] ]
-
-def column_to_block_coord(column, blocks):
-    for block_idx, block in enumerate(blocks):
-        try:
-            col_idx = block.index(column)
-        except ValueError:
-            continue
-        return (block_idx, col_idx)
-    raise ValueError(f"Column {column} not found in any block")
-
-def make_pandas_dataframe(index, series):
-    return pd.DataFrame(
-        {name: values for name, values in series.items()},
-        index=pd.DatetimeIndex(index)
-    )
 
 
 """

--- a/hydra_base/lib/storage/hdfstorageadapter.py
+++ b/hydra_base/lib/storage/hdfstorageadapter.py
@@ -127,6 +127,11 @@ class HdfStorageAdapter():
         return reader.get_index_info()
 
     @filestore_url("url")
+    def get_index_range(self, url, groupname, start=0, end=None):
+        reader = self.make_group_reader(url, groupname)
+        return reader.get_index_range(start, end)
+
+    @filestore_url("url")
     def get_series_info(self, url, groupname=None, columns=None):
         reader = self.make_group_reader(url, groupname)
         if isinstance(columns, str):

--- a/hydra_base/lib/storage/readers.py
+++ b/hydra_base/lib/storage/readers.py
@@ -1,0 +1,234 @@
+import logging
+import numpy as np
+import pandas as pd
+
+from datetime import datetime
+
+log = logging.getLogger(__name__)
+
+
+class FrameGroupReader():
+    """
+      pandas_type == "frame"
+    """
+    def __init__(self, hf, groupname):
+        self.hf = hf
+        try:
+            self.group = hf[groupname]
+        except KeyError as ke:
+            raise ValueError(f"Error: file {hf.filename} contains no group {groupname}") from ke
+
+    def get_columns_of_group(self):
+        try:
+            columns_raw = [*self.group["axis0"]]
+        except KeyError as ke:
+            raise ValueError(f"Error: {self.group.name} has invalid format") from ke
+        return [col.decode() for col in columns_raw]
+
+    def get_columns_by_block(self):
+        try:
+            nblocks = self.group.attrs["nblocks"]
+        except KeyError as ke:
+            raise KeyError(f"Error: group {self.group.name} contains no blocks") from ke
+        blocks_columns = []
+        for block_idx in range(nblocks):
+            columns_raw = [*self.group[f"block{block_idx}_items"]]
+            blocks_columns.append([col.decode() for col in columns_raw])
+        return blocks_columns
+
+    def make_column_map_of_group(self, blocks):
+        group_cols = self.get_columns_of_group()
+        return [column_to_block_coord(column, blocks) for column in group_cols]
+
+    def get_series_by_column_names(self, column_names, start=None, end=None):
+        columns = self.get_columns_of_group()
+        block_columns = self.get_columns_by_block()
+
+        column_map = self.make_column_map_of_group(block_columns)
+        named_map = {cname: cmap for cname, cmap in zip(columns, column_map)}
+
+        _, col_sz = self.get_group_shape()
+
+        start = start or 0
+        end = end or col_sz
+        column_series = {}
+        for column_name in column_names:
+            block_idx, col_idx = named_map[column_name]
+            block_values_name = f"block{block_idx}_values"
+            block_values = self.group[block_values_name]
+            section = np.array([row[col_idx] for row in block_values[start:end]])
+            column_series[column_name] = section
+
+        return column_series
+
+    def find_index_axis_index(self):
+        for ent in self.group:
+            try:
+                index_class = self.group[ent].attrs["index_class"]
+                return ent
+            except KeyError:
+                continue
+
+        raise ValueError(f"Group {self.group.name} of pandas_type "
+                          "'frame' contains no index axis")
+
+    def get_index_range(self, start=None, end=None):
+        index_axis = self.find_index_axis_index()
+        index = self.group[index_axis]
+        start = start or 0
+        end = end or len(index)
+        return [nscale(row) for row in index[start:end]]
+
+    def get_columns_as_dataframe(self, columns, start=None, end=None):
+        index_range = self.get_index_range(start, end)
+        column_series = self.get_series_by_column_names(columns, start, end)
+        return make_pandas_dataframe(index_range, column_series)
+
+    def get_group_shape(self):
+        row_sz = len(self.group["axis1"])
+        col_sz = len(self.get_columns_of_group())
+        return (row_sz, col_sz)
+
+
+class FrameTableGroupReader():
+    """
+      pandas_type == "frame_table"
+    """
+    def __init__(self, hf, groupname):
+        self.hf = hf
+        try:
+            self.group = hf[groupname]
+        except KeyError as ke:
+            raise ValueError(f"Error: file {hf.filename} contains no group {groupname}") from ke
+        try:
+            self.table = self.group["table"]
+        except KeyError as ke:
+            raise ValueError(f"Error: file {hf.filename} has invalid format, no 'table'") from ke
+
+    def get_index_column_index(self):
+        max_index_depth = 128
+        try:
+            index_cols_raw = self.group.attrs["index_cols"].decode().split('\n')[2:-2:2]
+        except KeyError:
+            # No index columns present
+            return None
+        index_cols = trim_x_first_y_rest(1, 2, index_cols_raw)
+        index_name = index_cols[0]  # Assume single index
+
+        for field_idx in range(max_index_depth):
+            try:
+                field_name = self.table.attrs[f"FIELD_{field_idx}_NAME"]
+            except KeyError:
+                # No field has the name of the stated index column
+                return None
+            if field_name.decode() == index_name:
+                return field_idx
+
+    def get_values_start_block_index(self):
+        max_value_depth = 128
+        try:
+            value_cols_raw = self.group.attrs["values_cols"].decode().split('\n')[1:-1:2]
+        except KeyError:
+            # Group contains no value columns
+            return None
+        value_cols = trim_x_first_y_rest(1, 2, value_cols_raw)
+        first_value_col = value_cols[0]
+
+        for field_idx in range(max_value_depth):
+            try:
+                field_name = self.table.attrs[f"FIELD_{field_idx}_NAME"]
+            except KeyError:
+                # No more fields
+                return None
+            if field_name.decode() == first_value_col:
+                return field_idx
+
+    def get_index_range(self, start=None, end=None):
+        start = start or 0
+        end = end or len(self.table)
+
+        index_idx = self.get_index_column_index()
+        if index_idx is None:
+            return []
+        return [nscale(row[index_idx]) for row in self.table[start:end]]
+
+    def get_columns_by_block(self):
+        value_cols_raw = self.group.attrs["values_cols"].decode().split('\n')[1:-1:2]
+        value_cols = trim_x_first_y_rest(1, 2, value_cols_raw)
+
+        block_columns = []
+        for field_idx, field_name in enumerate(value_cols, start=1):
+            kind = self.table.attrs[f"{field_name}_kind"]
+            kind_cols_raw = kind.decode().split('\n')[1:-1:2]
+            kind_cols = trim_x_first_y_rest(1, 2, kind_cols_raw)
+            block_columns.append(kind_cols)
+
+        return block_columns
+
+    def get_series_by_column_names(self, column_names, start=None, end=None):
+        columns = self.get_columns_of_group()
+        block_columns = self.get_columns_by_block()
+
+        column_map = self.make_column_map_of_group(block_columns)
+        named_map = {cname: cmap for cname, cmap in zip(columns, column_map)}
+
+        first_value_block_idx = self.get_values_start_block_index()
+
+        start = start or 0
+        end = end or len(self.table)
+        column_series = {}
+        for column_name in column_names:
+            block_idx, col_idx = named_map[column_name]
+            block_rows = np.array([row[block_idx+first_value_block_idx] for row in self.table[start:end]])
+            section = block_rows[:, col_idx]
+            column_series[column_name] = section
+
+        return column_series
+
+    def get_columns_as_dataframe(self, columns, start=None, end=None):
+        index_range = self.get_index_range(start, end)
+        column_series = self.get_series_by_column_names(columns, start, end)
+        return make_pandas_dataframe(index_range, column_series)
+
+    def make_column_map_of_group(self, blocks):
+        non_index_cols = self.get_columns_of_group()
+        return [column_to_block_coord(column, blocks) for column in non_index_cols]
+
+    def get_columns_of_group(self):
+        non_index_cols_raw = self.group.attrs["non_index_axes"].decode().split("\n")[3:-3:2]
+        return trim_x_first_y_rest(1, 2, non_index_cols_raw)
+
+    def get_group_shape(self):
+        row_sz = len(self.table)
+        col_sz = len(self.get_columns_of_group())
+        return (row_sz, col_sz)
+
+
+"""
+  Auxiliary Functions
+"""
+
+def nscale(ts):
+    """
+      Transforms integers representing nanoseconds past the epoch
+      into instances of datetime.timestamp
+    """
+    return datetime.fromtimestamp(ts/1e9)
+
+def trim_x_first_y_rest(x, y, names):
+    return [names[0][x:], *[name[y:] for name in names[1:]] ]
+
+def column_to_block_coord(column, blocks):
+    for block_idx, block in enumerate(blocks):
+        try:
+            col_idx = block.index(column)
+        except ValueError:
+            continue
+        return (block_idx, col_idx)
+    raise ValueError(f"Column {column} not found in any block")
+
+def make_pandas_dataframe(index, series):
+    return pd.DataFrame(
+        {name: values for name, values in series.items()},
+        index=pd.DatetimeIndex(index)
+    )

--- a/hydra_base/lib/storage/readers.py
+++ b/hydra_base/lib/storage/readers.py
@@ -16,8 +16,10 @@ class GroupReader(ABC):
       Each subclass must define a class attribute of <subclass_type_key>
       which contains a string identifying the Group type handled by that
       reader.
-      These attributes then populate the group_reader_map which is used
-      by the adapter to instantiate the correct reader for a given group
+      These attributes then automatically populate the group_reader_map
+      when a subclass is defined.  This map is then used by the adapter
+      to instantiate the correct reader for the intercal format of a
+      given group.
     """
 
     subclass_type_key = "pandas_type"
@@ -57,6 +59,14 @@ class GroupReader(ABC):
 
 
 class FrameGroupReader(GroupReader):
+    """
+    Reader for groups where the `pandas_type` attribute of the HDF group is "frame".
+    This corresponds to a group where the application-level DataFrame is decomposed
+    into `axis` and `block` components which are described by a collection of
+    attributes and datasets inside the HDF group.
+    The base class abstract methods are overridden in this class to provide
+    implementations which deal specifically with groups of this format.
+    """
     pandas_type = "frame"
 
     def __init__(self, hf, groupname):
@@ -196,6 +206,16 @@ class FrameGroupReader(GroupReader):
 
 
 class FrameTableGroupReader(GroupReader):
+    """
+    Reader for groups where the `pandas_type` attribute of the HDF group is "frame_table".
+    This category of group stores the description of the layout of a DataFrame over
+    attributes of the group itself and of a `table` dataset contained in the group.
+    The "index_cols" attribute of a group stores the set of column names and the
+    `FIELD_x` and `values_block_x` attributes of the dataset indicate in which of the
+    dtype-specific columns of the dataset a particular series can be found.
+    The base class abstract methods are overridden in this class to provide
+    implementations which deal specifically with groups of this format.
+    """
     pandas_type = "frame_table"
 
     def __init__(self, hf, groupname):

--- a/tests/test_hdf.py
+++ b/tests/test_hdf.py
@@ -28,9 +28,9 @@ def aws_file():
     return {
         "path": "s3://modelers-data-bucket/eapp/single/ETH_flow_sim.h5",
         "file_size": 7374454,
-        "dataset_name": "BR_Kabura",
-        "dataset_size": 12784,
-        "dataset_type": "float64"
+        "series_name": "BR_Kabura",
+        "series_size": 12784,
+        "series_type": "float64"
     }
 
 @pytest.fixture
@@ -67,18 +67,18 @@ class TestHdf():
         """
           Does the reported file size match an expected value?
         """
-        assert hdf.size(aws_file["path"]) == aws_file["file_size"]
+        assert hdf.file_size(aws_file["path"]) == aws_file["file_size"]
 
     @pytest.mark.requires_hdf
     def test_hdf_info(self, hdf, aws_file):
         """
           Do the reported properties of a dataset match expected values?
         """
-        info = hdf.get_dataset_info_url(aws_file["path"], aws_file["dataset_name"])
+        info = hdf.get_series_info(aws_file["path"], columns=aws_file["series_name"])
 
-        assert info["name"] == aws_file["dataset_name"]
-        assert info["size"] == aws_file["dataset_size"]
-        assert info["dtype"] == aws_file["dataset_type"]
+        assert info[0]["name"] == aws_file["series_name"]
+        assert info[0]["length"] == aws_file["series_size"]
+        assert info[0]["dtype"] == aws_file["series_type"]
 
     @pytest.mark.requires_hdf
     def test_hdf_dataset(self, hdf, aws_file):
@@ -87,7 +87,7 @@ class TestHdf():
           index and series values?
         """
         expected = {
-            aws_file["dataset_name"]: {
+            aws_file["series_name"]: {
                 (8,16): { "1972-01-09": 0.65664,
                           "1972-01-10": 0.65664,
                           "1972-01-11": 0.65664,
@@ -107,12 +107,12 @@ class TestHdf():
                                  "2004-11-23": 1.2528}
             }
         }
-        for dataset_name, ranges in expected.items():
+        for series_name, ranges in expected.items():
             for bounds, data in ranges.items():
-                df_json = hdf.get_columns_as_dataframe(aws_file["path"], dataset_name, *bounds)
+                df_json = hdf.get_columns_as_dataframe(aws_file["path"], columns=[series_name], start=bounds[0], end=bounds[1])
                 df = pd.read_json(df_json)
                 for ts, val in data.items():
-                    assert np.isclose(df[dataset_name][ts], val)
+                    assert np.isclose(df[series_name][ts], val)
 
     @pytest.mark.requires_hdf
     def test_hydra_hdf_size(self, aws_file):
@@ -120,19 +120,19 @@ class TestHdf():
           Does the reported file size match an expected value when
           accessed via hydra.lib?
         """
-        assert data.get_hdf_filesize(aws_file["path"]) == aws_file["file_size"]
+        assert data.get_hdf_file_size(aws_file["path"]) == aws_file["file_size"]
 
     @pytest.mark.requires_hdf
     def test_hydra_hdf_info(self, aws_file):
         """
-          Do the reported properties of a dataset match expected values when
+          Do the reported properties of a series match expected values when
           accessed via hydra.lib?
         """
-        info = data.get_hdf_dataset_info(aws_file["path"], aws_file["dataset_name"])
+        info = data.get_hdf_group_info(aws_file["path"])
 
-        assert info["name"] == aws_file["dataset_name"]
-        assert info["size"] == aws_file["dataset_size"]
-        assert info["dtype"] == aws_file["dataset_type"]
+        assert info["index"] == {'name': 'timestamp', 'length': 12784, 'dtype': 'datetime64'}
+        assert len(info["series"]) == 71
+        assert info["series"][0] == {'name': 'BR_Bendera (Ruzizi 0.035)', 'length': 12784, 'dtype': 'float64'}
 
     @pytest.mark.requires_hdf
     def test_hydra_hdf_dataset(self, aws_file):
@@ -141,7 +141,7 @@ class TestHdf():
           index and series values when accessed via hydra.lib?
         """
         expected = {
-            aws_file["dataset_name"]: {
+            aws_file["series_name"]: {
                 (8,16): { "1972-01-09": 0.65664,
                           "1972-01-10": 0.65664,
                           "1972-01-11": 0.65664,
@@ -161,12 +161,12 @@ class TestHdf():
                                  "2004-11-23": 1.2528}
             }
         }
-        for dataset_name, ranges in expected.items():
+        for series_name, ranges in expected.items():
             for bounds, series in ranges.items():
-                df_json = data.get_columns_as_dataframe(aws_file["path"], groupname=None, columns=[dataset_name], start=bounds[0], end=bounds[1])
+                df_json = data.get_hdf_columns_as_dataframe(aws_file["path"], groupname=None, columns=[series_name], start=bounds[0], end=bounds[1])
                 df = pd.read_json(df_json)
                 for ts, val in series.items():
-                    assert np.isclose(df[dataset_name][ts], val)
+                    assert np.isclose(df[series_name][ts], val)
 
     @pytest.mark.requires_hdf
     def test_bad_url(self, bad_url):
@@ -174,19 +174,19 @@ class TestHdf():
           Does an inaccessible url raise ValueError?
         """
         with pytest.raises(ValueError):
-            info = data.get_hdf_dataset_info(bad_url, "dataset_name")
+            info = data.get_hdf_series_info(bad_url, "series_name")
 
     @pytest.mark.requires_hdf
-    def test_bad_dataset_name(self, aws_file):
+    def test_bad_series_name(self, aws_file):
         """
           Does a nonexistent dataset name raise ValueError both for
           info and series retrieval?
         """
         with pytest.raises(ValueError):
-            info = data.get_hdf_dataset_info(aws_file["path"], "nonexistent_dataset")
+            info = data.get_hdf_series_info(aws_file["path"], "nonexistent_series")
 
         with pytest.raises(ValueError):
-            df_json = data.get_hdf_dataframe(aws_file["path"], "nonexistent_dataset", 8, 16)
+            df_json = data.get_hdf_columns_as_dataframe(aws_file["path"], columns=["nonexistent_series"], start=8, end=16)
 
     @pytest.mark.requires_hdf
     def test_bad_bounds(self, aws_file):
@@ -194,16 +194,16 @@ class TestHdf():
           Do invalid bounds (start<0, start>end, end<0, end>size) raise ValueError?
         """
         with pytest.raises(ValueError):
-            df_json = data.get_hdf_dataframe(aws_file["path"], aws_file["dataset_name"], -1, 16)
+            df_json = data.get_hdf_group_as_dataframe(aws_file["path"], start=-1, end=16)
 
         with pytest.raises(ValueError):
-            df_json = data.get_hdf_dataframe(aws_file["path"], aws_file["dataset_name"], 16, 8)
+            df_json = data.get_hdf_group_as_dataframe(aws_file["path"], start=16, end=8)
 
         with pytest.raises(ValueError):
-            df_json = data.get_hdf_dataframe(aws_file["path"], aws_file["dataset_name"], 8, -1)
+            df_json = data.get_hdf_group_as_dataframe(aws_file["path"], start=8, end=-1)
 
         with pytest.raises(ValueError):
-            df_json = data.get_hdf_dataframe(aws_file["path"], aws_file["dataset_name"], 8, 1e72)
+            df_json = data.get_hdf_group_as_dataframe(aws_file["path"], start=8, end=1e72)
 
     @pytest.mark.requires_hdf
     def test_bad_url_does_not_exist(self, bad_url):
@@ -242,17 +242,6 @@ class TestHdf():
         assert na[2] == None
 
     @pytest.mark.requires_hdf
-    def test_multigroup_dataframe(self, multigroup_file):
-        """
-          Is the correct dataframe returned when requesting a whole
-          dataframe from a remote multigroup file?
-
-          NB rot13 strings
-        """
-        df = data.get_hdf_group_as_dataframe(multigroup_file["path"], groupname="RFJ_Rffrk_erfhygf")
-        assert df[:94] == '{"Ynatunz Vagnxr.Fhccyl.Nzbhag":{"1910-01-01T00:00:00.000":40.0,"1910-01-02T00:00:00.000":40.0'
-
-    @pytest.mark.requires_hdf
     def test_multigroup_series(self, multigroup_file):
         """
           Is the correct series returned when requesting a particular
@@ -260,8 +249,11 @@ class TestHdf():
 
           NB rot13 strings
         """
-        df = data.get_hdf_group_as_dataframe(multigroup_file["path"], groupname="RFJ_Rffrk_erfhygf", series="Jbezvatsbeq Vagnxr.Fhccyl.Nzbhag")
-        assert df[:93] == '{"1910-01-01T00:00:00.000":0.0,"1910-01-02T00:00:00.000":0.0,"1910-01-03T00:00:00.000":0.0,"1'
+        df = data.get_hdf_columns_as_dataframe(multigroup_file["path"],
+                                               groupname="RFJ_Rffrk_erfhygf",
+                                               columns=["Jbezvatsbeq Vagnxr.Fhccyl.Nzbhag"],
+                                               end=256)
+        assert df[:92] == '{"Jbezvatsbeq Vagnxr.Fhccyl.Nzbhag":{"1910-01-01T00:00:00.000":0.0,"1910-01-02T00:00:00.000"'
 
     @pytest.mark.requires_hdf
     def test_hdf_multigroups(self, multigroup_file):
@@ -274,9 +266,18 @@ class TestHdf():
         assert set(groups) == set(multigroup_file["groups"])
 
     @pytest.mark.requires_hdf
-    def test_get_hdf_multigroup_subset(self, multigroup_file):
-        df_json = data.get_hdf_dataframe(multigroup_file["path"], "Qraire Vagnxr.Fhccyl.Nzbhag", 4, 8, groupname="RFJ_Rffrk_erfhygf")
-        assert df_json == '{"Qraire Vagnxr.Fhccyl.Nzbhag":{"1910-01-05T00:00:00.000":61.19238,"1910-01-06T00:00:00.000":77.95459,"1910-01-07T00:00:00.000":106.8699,"1910-01-08T00:00:00.000":119.7732}}'
+    def test_get_hdf_whole_group_as_dataframe(self, multigroup_file):
+        """
+          Does retrieving a selection of rows from a whole Group
+          return the correct section?
+
+          NB rot13 strings
+        """
+        df_json = data.get_hdf_group_as_dataframe(multigroup_file["path"],
+                                                  groupname="RFJ_Rffrk_erfhygf",
+                                                  start=4, end=8)
+        assert df_json[:126] == '{"Ynatunz Vagnxr.Fhccyl.Nzbhag":{"1910-01-05T00:00:00.000":40.0,'\
+                                '"1910-01-06T00:00:00.000":40.0,"1910-01-07T00:00:00.000":40.0,'
 
     @pytest.mark.requires_hdf
     def test_hdf_group_columns(self, multigroup_file):

--- a/tests/test_hdf.py
+++ b/tests/test_hdf.py
@@ -5,7 +5,6 @@ import pytest
 
 from packaging import version
 
-from hydra_base.lib import data
 from hydra_base.lib.storage import HdfStorageAdapter
 from hydra_base.util import NullAdapter
 
@@ -130,27 +129,27 @@ class TestHdf():
                     assert np.isclose(df[series_name][ts], val)
 
     @pytest.mark.requires_hdf
-    def test_hydra_hdf_size(self, aws_file):
+    def test_hydra_hdf_size(self, client, aws_file):
         """
           Does the reported file size match an expected value when
           accessed via hydra.lib?
         """
-        assert data.get_hdf_file_size(aws_file["path"]) == aws_file["file_size"]
+        assert client.get_hdf_file_size(aws_file["path"]) == aws_file["file_size"]
 
     @pytest.mark.requires_hdf
-    def test_hydra_hdf_info(self, aws_file):
+    def test_hydra_hdf_info(self, client, aws_file):
         """
           Do the reported properties of a series match expected values when
           accessed via hydra.lib?
         """
-        info = data.get_hdf_group_info(aws_file["path"])
+        info = client.get_hdf_group_info(aws_file["path"])
 
         assert info["index"] == {'name': 'timestamp', 'length': 12784, 'dtype': 'datetime64'}
         assert len(info["series"]) == 71
         assert info["series"][0] == {'name': 'BR_Bendera (Ruzizi 0.035)', 'length': 12784, 'dtype': 'float64'}
 
     @pytest.mark.requires_hdf
-    def test_hydra_hdf_dataset(self, aws_file):
+    def test_hydra_hdf_dataset(self, client, aws_file):
         """
           Does a specified subset of a dataset match its expected
           index and series values when accessed via hydra.lib?
@@ -178,63 +177,63 @@ class TestHdf():
         }
         for series_name, ranges in expected.items():
             for bounds, series in ranges.items():
-                df_json = data.get_hdf_columns_as_dataframe(aws_file["path"], groupname=None, columns=[series_name], start=bounds[0], end=bounds[1])
+                df_json = client.get_hdf_columns_as_dataframe(aws_file["path"], groupname=None, columns=[series_name], start=bounds[0], end=bounds[1])
                 df = pd.read_json(df_json)
                 for ts, val in series.items():
                     assert np.isclose(df[series_name][ts], val)
 
     @pytest.mark.requires_hdf
-    def test_bad_url(self, bad_url):
+    def test_bad_url(self, client, bad_url):
         """
           Does an inaccessible url raise ValueError?
         """
         with pytest.raises(ValueError):
-            info = data.get_hdf_series_info(bad_url, "series_name")
+            info = client.get_hdf_series_info(bad_url, "series_name")
 
     @pytest.mark.requires_hdf
-    def test_bad_series_name(self, aws_file):
+    def test_bad_series_name(self, client, aws_file):
         """
           Does a nonexistent dataset name raise ValueError both for
           info and series retrieval?
         """
         with pytest.raises(ValueError):
-            info = data.get_hdf_series_info(aws_file["path"], "nonexistent_series")
+            info = client.get_hdf_series_info(aws_file["path"], "nonexistent_series")
 
         with pytest.raises(ValueError):
-            df_json = data.get_hdf_columns_as_dataframe(aws_file["path"], columns=["nonexistent_series"], start=8, end=16)
+            df_json = client.get_hdf_columns_as_dataframe(aws_file["path"], columns=["nonexistent_series"], start=8, end=16)
 
     @pytest.mark.requires_hdf
-    def test_bad_bounds(self, aws_file):
+    def test_bad_bounds(self, client, aws_file):
         """
           Do invalid bounds (start<0, start>end, end<0, end>size) raise ValueError?
         """
         with pytest.raises(ValueError):
-            df_json = data.get_hdf_group_as_dataframe(aws_file["path"], start=-1, end=16)
+            df_json = client.get_hdf_group_as_dataframe(aws_file["path"], start=-1, end=16)
 
         with pytest.raises(ValueError):
-            df_json = data.get_hdf_group_as_dataframe(aws_file["path"], start=16, end=8)
+            df_json = client.get_hdf_group_as_dataframe(aws_file["path"], start=16, end=8)
 
         with pytest.raises(ValueError):
-            df_json = data.get_hdf_group_as_dataframe(aws_file["path"], start=8, end=-1)
+            df_json = client.get_hdf_group_as_dataframe(aws_file["path"], start=8, end=-1)
 
         with pytest.raises(ValueError):
-            df_json = data.get_hdf_group_as_dataframe(aws_file["path"], start=8, end=1e72)
+            df_json = client.get_hdf_group_as_dataframe(aws_file["path"], start=8, end=1e72)
 
     @pytest.mark.requires_hdf
-    def test_bad_url_does_not_exist(self, bad_url):
+    def test_bad_url_does_not_exist(self, client, bad_url):
         """
           Does data.file_exists_at_url() return False for nonexistent
           files on remote or local filesystem?
         """
-        assert not data.file_exists_at_url(bad_url)
+        assert not client.file_exists_at_url(bad_url)
 
     @pytest.mark.requires_hdf
-    def test_existing_file_at_url_exists(self, aws_file):
+    def test_existing_file_at_url_exists(self, client, aws_file):
         """
           Does data.file_exists_at_url() return True for existing
           files on remote or local filesystem?
         """
-        assert data.file_exists_at_url(aws_file["path"])
+        assert client.file_exists_at_url(aws_file["path"])
 
     def test_nulladapter_is_null(self):
         """
@@ -257,58 +256,58 @@ class TestHdf():
         assert na[2] == None
 
     @pytest.mark.requires_hdf
-    def test_multigroup_series(self, multigroup_file):
+    def test_multigroup_series(self, client, multigroup_file):
         """
           Is the correct series returned when requesting a particular
           series from a dataframe in a multigroup file?
 
           NB rot13 strings
         """
-        df = data.get_hdf_columns_as_dataframe(multigroup_file["path"],
+        df = client.get_hdf_columns_as_dataframe(multigroup_file["path"],
                                                groupname="RFJ_Rffrk_erfhygf",
                                                columns=["Jbezvatsbeq Vagnxr.Fhccyl.Nzbhag"],
                                                end=256)
         assert df[:92] == '{"Jbezvatsbeq Vagnxr.Fhccyl.Nzbhag":{"1910-01-01T00:00:00.000":0.0,"1910-01-02T00:00:00.000"'
 
     @pytest.mark.requires_hdf
-    def test_hdf_multigroups(self, multigroup_file):
+    def test_hdf_multigroups(self, client, multigroup_file):
         """
           Are the expected groups returned when querying an HDF file for its root groups?
 
           NB rot13 strings
         """
-        groups = data.get_hdf_groups(multigroup_file["path"])
+        groups = client.get_hdf_groups(multigroup_file["path"])
         assert set(groups) == set(multigroup_file["groups"])
 
     @pytest.mark.requires_hdf
-    def test_get_hdf_whole_group_as_dataframe(self, multigroup_file):
+    def test_get_hdf_whole_group_as_dataframe(self, client, multigroup_file):
         """
           Does retrieving a selection of rows from a whole Group
           return the correct section?
 
           NB rot13 strings
         """
-        df_json = data.get_hdf_group_as_dataframe(multigroup_file["path"],
+        df_json = client.get_hdf_group_as_dataframe(multigroup_file["path"],
                                                   groupname="RFJ_Rffrk_erfhygf",
                                                   start=4, end=8)
         assert df_json[:126] == '{"Ynatunz Vagnxr.Fhccyl.Nzbhag":{"1910-01-05T00:00:00.000":40.0,'\
                                 '"1910-01-06T00:00:00.000":40.0,"1910-01-07T00:00:00.000":40.0,'
 
     @pytest.mark.requires_hdf
-    def test_hdf_group_columns(self, multigroup_file):
+    def test_hdf_group_columns(self, client, multigroup_file):
         """
           Are the correct columns in the correct order returned from a group dataframe?
 
           NB rot13 strings
         """
-        columns = data.get_hdf_group_columns(multigroup_file["path"], groupname="RFJ_Rffrk_erfhygf")
+        columns = client.get_hdf_group_columns(multigroup_file["path"], groupname="RFJ_Rffrk_erfhygf")
         assert len(columns) == 109
         assert columns[2] == 'Qraire Vagnxr.Fhccyl.Nzbhag'
         assert 'Unaavatsvryq Erfreibve.Fgbentr.Pnyphyngrq (%)' in columns
 
     @pytest.mark.requires_hdf
     @pytest.mark.parametrize("pathname, path", {**bad_paths, **{"symlink_path": symlink_path}}.items())
-    def test_purge_file(self, hdf, pathname, path, request):
+    def test_purge_file(self, client, hdf, pathname, path, request):
         """
           This tests the operation of HdfStorageAdapter.purge_local_file()
           This is an inherently dangerous function which allows a file specified
@@ -320,8 +319,10 @@ class TestHdf():
         """
         fsp = hdf.filestore_path
         try:
+            # The symlink_path is just a ref to the fixture func
+            # so make pytest replace the ref with its value
             path = request.getfixturevalue(pathname)
         except:
             pass
         with pytest.raises(ValueError):
-            hdf.purge_local_file(os.path.join(fsp, path))
+            client.purge_local_file(os.path.join(fsp, path))

--- a/tests/test_hdf.py
+++ b/tests/test_hdf.py
@@ -109,7 +109,7 @@ class TestHdf():
         }
         for dataset_name, ranges in expected.items():
             for bounds, data in ranges.items():
-                df_json = hdf.hdf_dataset_to_pandas_dataframe(aws_file["path"], dataset_name, *bounds)
+                df_json = hdf.get_columns_as_dataframe(aws_file["path"], dataset_name, *bounds)
                 df = pd.read_json(df_json)
                 for ts, val in data.items():
                     assert np.isclose(df[dataset_name][ts], val)
@@ -163,7 +163,7 @@ class TestHdf():
         }
         for dataset_name, ranges in expected.items():
             for bounds, series in ranges.items():
-                df_json = data.get_hdf_dataframe(aws_file["path"], dataset_name, *bounds)
+                df_json = data.get_columns_as_dataframe(aws_file["path"], groupname=None, columns=[dataset_name], start=bounds[0], end=bounds[1])
                 df = pd.read_json(df_json)
                 for ts, val in series.items():
                     assert np.isclose(df[dataset_name][ts], val)

--- a/tests/test_hdf.py
+++ b/tests/test_hdf.py
@@ -326,3 +326,28 @@ class TestHdf():
             pass
         with pytest.raises(ValueError):
             client.purge_local_file(os.path.join(fsp, path))
+
+    @pytest.mark.requires_hdf
+    @pytest.mark.parametrize("file, file_info", [("aws_file", aws_file), ("multigroup_file", multigroup_file)])
+    def test_index_info(self, client, file, file_info, request):
+        try:
+            file_info = request.getfixturevalue(file)
+        except:
+            pass
+        groups = client.get_hdf_groups(file_info["path"])
+        ii = client.get_hdf_index_info(file_info["path"], groupname=groups[0])
+        for key in ("name", "length", "dtype"):
+            assert key in ii
+        assert isinstance(ii, dict)
+
+    @pytest.mark.requires_hdf
+    @pytest.mark.parametrize("file, file_info", [("aws_file", aws_file), ("multigroup_file", multigroup_file)])
+    def test_index_range(self, client, file, file_info, request):
+        try:
+            file_info = request.getfixturevalue(file)
+        except:
+            pass
+        groups = client.get_hdf_groups(file_info["path"])
+        ir = client.get_hdf_index_range(file_info["path"], groupname=groups[0], start=2, end=8)
+        assert len(ir) > 0
+        assert isinstance(ir[0], str)


### PR DESCRIPTION
This additional allows the adapter layer to present remotely-accessed HDF datasets as pandas.DataFrames for all supported types, and introduces a consistent interface for extending this to additional types.
* [Tests pass](https://github.com/hydraplatform/hydra-base/actions/runs/3714970117)
* The adapter can now transparently identify different HDF file types and select an appropriate `GroupReader` subclass. These present a consistent interface enforced by an abc.
* Utility functions to report the groups in a file, the series in a group, the index of a series, and the shape and datatype of series are available.
* Remote partial access is supported for all HDF file types. In addition, a function to explicitly force retrieval of a file from s3 storage to the local filesystem is available.
* Note that there are api changes relative to the previous version.