### PR TITLE
Use the database to store the beaker cache instead of using a file

### DIFF
--- a/hydra_base/lib/service.py
+++ b/hydra_base/lib/service.py
@@ -21,6 +21,7 @@ from beaker import session
 
 from .. import util
 from .. import config
+from .. import db
 
 DEFAULT_VALIDATE_KEY = 'YxaDbzUUSo08b+'
 DEFAULT_DATA_DIR = '/tmp'
@@ -47,10 +48,10 @@ def login(username, password, **kwargs):
     hydra_session = session.Session(
         {}, #This is normally a request object, but in this case is empty
         validate_key=config.get('COOKIES', 'VALIDATE_KEY', DEFAULT_VALIDATE_KEY),
-        type='file',
+        type='file' if db.hydra_db_url.startswith('sqlite') else 'ext:database',
         cookie_expires=True,
         data_dir=config.get('COOKIES', 'DATA_DIR', DEFAULT_DATA_DIR),
-        file_dir=config.get('COOKIES', 'FILE_DIR', DEFAULT_FILE_DIR)
+        url=db.hydra_db_url
     )
 
     hydra_session['user_id'] = user_id
@@ -75,10 +76,10 @@ def logout(session_id, **kwargs):
     hydra_session_object = session.SessionObject(
         {}, #This is normally a request object, but in this case is empty
         validate_key=config.get('COOKIES', 'VALIDATE_KEY', DEFAULT_VALIDATE_KEY),
-        type='file',
+        type='file' if db.hydra_db_url.startswith('sqlite') else 'ext:database',
         cookie_expires=True,
         data_dir=config.get('COOKIES', 'DATA_DIR', DEFAULT_DATA_DIR),
-        file_dir=config.get('COOKIES', 'FILE_DIR', DEFAULT_FILE_DIR))
+        url=db.hydra_db_url)
 
     hydra_session = hydra_session_object.get_by_id(session_id)
 
@@ -102,10 +103,10 @@ def get_session_user(session_id, **kwargs):
     hydra_session_object = session.SessionObject(
         {}, #This is normally a request object, but in this case is empty
         validate_key=config.get('COOKIES', 'VALIDATE_KEY', DEFAULT_VALIDATE_KEY),
-        type='file',
+        type='file' if db.hydra_db_url.startswith('sqlite') else 'ext:database',
         cookie_expires=True,
         data_dir=config.get('COOKIES', 'DATA_DIR', DEFAULT_DATA_DIR),
-        file_dir=config.get('COOKIES', 'FILE_DIR', DEFAULT_FILE_DIR))
+        url=db.hydra_db_url)
 
     hydra_session = hydra_session_object.get_by_id(session_id)
 

--- a/hydra_base/lib/service.py
+++ b/hydra_base/lib/service.py
@@ -111,6 +111,6 @@ def get_session_user(session_id, **kwargs):
     hydra_session = hydra_session_object.get_by_id(session_id)
 
     if hydra_session is not None:
-        return hydra_session['user_id']
+        return hydra_session
 
     return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ mysqlclient
 pudb
 python-dateutil
 cheroot
-beaker
+beaker==1.11.0
 click
 diskcache
 pylibmc

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires=[
     "mysqlclient",
     "python-dateutil",
     "cheroot",
-    "beaker",
+    "beaker==1.11.0",
     "packaging",
     "pymongo",
     "pylibmc",

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    order: set the order in which the test should be run. used to set it to 'last'


### PR DESCRIPTION
This changes the Beaker implementation to use a DB instead of a file when connected to mysql. 
This enables multiple independent services to all use the same user session