### PR TITLE
New rescope_attr routine and test; config project_max_nest_depth

### DIFF
--- a/hydra_base/hydra.ini
+++ b/hydra_base/hydra.ini
@@ -107,3 +107,6 @@ max_login_attempts = 7
 
 [cache]
 type=memcached
+
+[limits]
+project_max_nest_depth = 32


### PR DESCRIPTION
Resolves #176
* Test `different_projects_same_name_attributes` added to replicate issue with rescoping between peer projects
* Issue identified in `lib/attributes.py` `_reassign_scoped_attributes()` where any same-name-and-dimension attrs are deleted, irrespective of scope. This is resolved by scoping rattrs to project hierarchy and noting any cases of network attrs which are rescoped.
* Adds `project_max_nest_depth` and `limits` section of config. Currently only used as a sanity check in argument to `Project.get_child_projects()` but intention is to enforce this as policy on maximum permissible nesting of projects.