### PR TITLE
191 add basic statistical reporting to storage utils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Setup Memcache
         run: |
-             sudo apt-get install -y memcached=1.5.22
+             sudo apt-get install -y memcached=1.5.22-2
              sudo systemctl start memcached
 
       - name: Install hydra-base

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Setup Memcache
         run: |
-             sudo apt-get install -y memcached libmemcached11 libmemcached-dev libhashkit-dev
+             sudo apt-get install -y memcached=1.5.22
              sudo systemctl start memcached
 
       - name: Install hydra-base

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,7 @@ jobs:
 
       - name: Setup Memcache
         run: |
-             sudo apt-get install -y memcached
-             sudo apt-get install -y libmemcached-dev
+             sudo apt-get install -y memcached libmemcached libmemcached-dev
              sudo systemctl start memcached
 
       - name: Install hydra-base

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Setup Memcache
         run: |
-             sudo apt-get install -y memcached libmemcached libmemcached-dev
+             sudo apt-get install -y memcached libmemcached11 libmemcached-dev libhashkit-dev
              sudo systemctl start memcached
 
       - name: Install hydra-base

--- a/hydra_base/util/storage.py
+++ b/hydra_base/util/storage.py
@@ -132,7 +132,7 @@ def largest_documents(count: int=20, db_name: str=None, collection: str=None) ->
 
     pipeline = [
         {"$match": {"value": {"$exists": True}}},
-        {"$match": {"value": {"$ne": None}}},
+        {"$match": {"value": {"$type": "string"}}},  # Must ensure string args to strLenCP below
         {"$project": {
             "length": {"$strLenCP": "$value"}
             }
@@ -159,7 +159,7 @@ def document_distribution(db_name: str=None, collection: str=None, buckets: str=
     for bucket in hist:
         pipeline = [
             {"$match": {"value": {"$exists": True}}},
-            {"$match": {"value": {"$ne": None}}},
+            {"$match": {"value": {"$type": "string"}}},  # Must ensure string args to strLenCP below
             {"$redact": {"$cond": [ {"$gt": [{"$strLenCP": "$value"}, bucket["lower"]]}, "$$KEEP", "$$PRUNE"]}},
             {"$redact": {"$cond": [ {"$lte": [{"$strLenCP": "$value"}, bucket["upper"]]}, "$$KEEP", "$$PRUNE"]}},
             {"$count": "count"}


### PR DESCRIPTION
Adds reports for both Mongo and SQL dbs which describe the distribution of dataset sizes, containing:

- `count`: total number of datasets
- `total_size`: total size in bytes of datasets
- `mean_size`: `total_size`/`count`
- `distribution`: histogram of dataset sizes