### PR TITLE
get_resourcedata speed improvements

### DIFF
--- a/hydra_base/db/model/network/link.py
+++ b/hydra_base/db/model/network/link.py
@@ -19,10 +19,11 @@
 from ..base import *
 
 from .resourceattr import ResourceAttr
+from .resource import Resource
 
 __all__ = ['Link']
 
-class Link(Base, Inspect):
+class Link(Base, Inspect, Resource):
     """
     """
 

--- a/hydra_base/db/model/network/network.py
+++ b/hydra_base/db/model/network/network.py
@@ -28,12 +28,13 @@ from ..attributes import Attr
 from . import Link
 from . import Node
 from . import ResourceGroup
+from .resource import Resource
 
 __all__ = ['Network']
 
 
 
-class Network(Base, Inspect, PermissionControlled):
+class Network(Base, Inspect, PermissionControlled, Resource):
     """
     """
 

--- a/hydra_base/db/model/network/node.py
+++ b/hydra_base/db/model/network/node.py
@@ -18,10 +18,11 @@
 #
 from ..base import *
 from .resourceattr import ResourceAttr
+from .resource import Resource
 
 __all__ = ['Node']
 
-class Node(Base, Inspect):
+class Node(Base, Inspect, Resource):
     """
     """
 

--- a/hydra_base/db/model/network/resource.py
+++ b/hydra_base/db/model/network/resource.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# (c) Copyright 2013 to 2017 University of Manchester
+#
+# HydraPlatform is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HydraPlatform is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with HydraPlatform.  If not, see <http://www.gnu.org/licenses/>
+#
+from ..base import *
+from .resourceattr import ResourceAttr
+
+__all__ = ['Resource']
+
+class Resource:
+    def get_attributes(
+            self,
+            include_outputs=True,
+            include_inputs=True
+    ):
+        """
+        Get the resource attributes for this resource, with 
+        args:
+            include_outputs (bool): Include Resource Attributes tagged with attr_is_var='Y'
+            include_inputs (bool): Include Resource Attributes tagged with attr_is_var='N'
+        """
+
+        ra_qry = get_session().query(ResourceAttr).filter(
+            ResourceAttr.ref_id == self.id,
+            ResourceAttr.ref_key == self.ref_key
+        )
+
+        if include_inputs is not True:
+            ra_qry = ra_qry.filter(ResourceAttr.attr_is_var == 'N')
+        
+        if include_outputs is not True:
+            ra_qry = ra_qry.filter(ResourceAttr.attr_is_var == 'Y')
+
+        resource_attribtes = ra_qry.all()
+
+        return resource_attribtes

--- a/hydra_base/db/model/network/resource.py
+++ b/hydra_base/db/model/network/resource.py
@@ -56,6 +56,4 @@ class Resource:
                 #only include inputs
                 ra_qry = ra_qry.filter(ResourceAttr.attr_is_var == 'N')
 
-        resource_attribtes = ra_qry.all()
-
-        return resource_attribtes
+        return ra_qry.all()

--- a/hydra_base/db/model/network/resource.py
+++ b/hydra_base/db/model/network/resource.py
@@ -47,11 +47,14 @@ class Resource:
         elif self.ref_key == 'GROUP':
             ra_qry = ra_qry.filter(ResourceAttr.group_id==self.id)
 
-        if include_inputs is True:
-            ra_qry = ra_qry.filter(ResourceAttr.attr_is_var == 'N')
-        
-        if include_outputs is True:
-            ra_qry = ra_qry.filter(ResourceAttr.attr_is_var == 'Y')
+        if include_inputs is False or include_outputs is False:
+            if include_inputs is False:
+                #only include outputs
+                ra_qry = ra_qry.filter(ResourceAttr.attr_is_var == 'Y')
+            
+            if include_outputs is False:
+                #only include inputs
+                ra_qry = ra_qry.filter(ResourceAttr.attr_is_var == 'N')
 
         resource_attribtes = ra_qry.all()
 

--- a/hydra_base/db/model/network/resource.py
+++ b/hydra_base/db/model/network/resource.py
@@ -35,14 +35,22 @@ class Resource:
         """
 
         ra_qry = get_session().query(ResourceAttr).filter(
-            ResourceAttr.ref_id == self.id,
             ResourceAttr.ref_key == self.ref_key
         )
 
-        if include_inputs is not True:
+        if self.ref_key == 'NETWORK':
+            ra_qry = ra_qry.filter(ResourceAttr.network_id==self.id)
+        elif self.ref_key == 'NODE':
+            ra_qry = ra_qry.filter(ResourceAttr.node_id==self.id)
+        elif self.ref_key == 'LINK':
+            ra_qry = ra_qry.filter(ResourceAttr.link_id==self.id)
+        elif self.ref_key == 'GROUP':
+            ra_qry = ra_qry.filter(ResourceAttr.group_id==self.id)
+
+        if include_inputs is True and include_outputs is False:
             ra_qry = ra_qry.filter(ResourceAttr.attr_is_var == 'N')
         
-        if include_outputs is not True:
+        if include_outputs is True and include_inputs is False:
             ra_qry = ra_qry.filter(ResourceAttr.attr_is_var == 'Y')
 
         resource_attribtes = ra_qry.all()

--- a/hydra_base/db/model/network/resource.py
+++ b/hydra_base/db/model/network/resource.py
@@ -47,10 +47,10 @@ class Resource:
         elif self.ref_key == 'GROUP':
             ra_qry = ra_qry.filter(ResourceAttr.group_id==self.id)
 
-        if include_inputs is True and include_outputs is False:
+        if include_inputs is True:
             ra_qry = ra_qry.filter(ResourceAttr.attr_is_var == 'N')
         
-        if include_outputs is True and include_inputs is False:
+        if include_outputs is True:
             ra_qry = ra_qry.filter(ResourceAttr.attr_is_var == 'Y')
 
         resource_attribtes = ra_qry.all()

--- a/hydra_base/db/model/network/resourcegroup.py
+++ b/hydra_base/db/model/network/resourcegroup.py
@@ -19,10 +19,11 @@
 from ..base import *
 
 from .resourceattr import ResourceAttr
+from .resource import Resource
 
 __all__ = ['ResourceGroup']
 
-class ResourceGroup(Base, Inspect):
+class ResourceGroup(Base, Inspect, Resource):
     """
     """
 

--- a/hydra_base/db/model/project.py
+++ b/hydra_base/db/model/project.py
@@ -147,7 +147,7 @@ class Project(Base, Inspect, PermissionControlled):
             if child_proj_i.check_read_permission(user_id, do_raise=False) is True:
                 projects_with_access.append(child_proj_i)
 
-        owners = get_session().query(User.id.label('user_id'), User.display_name).filter(User.id==ProjectOwner.user_id).filter(ProjectOwner.project_id.in_([p.id for p in child_projects_i])).all()
+        owners = get_session().query(User.id.label('user_id'), User.display_name, ProjectOwner.project_id).filter(User.id==ProjectOwner.user_id).filter(ProjectOwner.project_id.in_([p.id for p in child_projects_i])).all()
         creators = get_session().query(User.id.label('user_id'), User.display_name).filter(User.id.in_([p.created_by for p in child_projects_i])).all()
         creator_lookup = {u.user_id:JSONObject(u)  for u in creators}
         owner_lookup = defaultdict(list)

--- a/hydra_base/db/model/project.py
+++ b/hydra_base/db/model/project.py
@@ -147,9 +147,9 @@ class Project(Base, Inspect, PermissionControlled):
             if child_proj_i.check_read_permission(user_id, do_raise=False) is True:
                 projects_with_access.append(child_proj_i)
 
-        owners = get_session().query(ProjectOwner).filter(ProjectOwner.project_id.in_([p.id for p in child_projects_i])).all()
-        creators = get_session().query(User.id, User.username, User.display_name).filter(User.id.in_([p.created_by for p in child_projects_i])).all()
-        creator_lookup = {u.id:JSONObject(u)  for u in creators}
+        owners = get_session().query(User.id.label('user_id'), User.display_name).filter(User.id==ProjectOwner.user_id).filter(ProjectOwner.project_id.in_([p.id for p in child_projects_i])).all()
+        creators = get_session().query(User.id.label('user_id'), User.display_name).filter(User.id.in_([p.created_by for p in child_projects_i])).all()
+        creator_lookup = {u.user_id:JSONObject(u)  for u in creators}
         owner_lookup = defaultdict(list)
         for p in child_projects_i:
             owner_lookup[p.id] = [creator_lookup[p.created_by]]

--- a/hydra_base/db/model/scenario/scenario.py
+++ b/hydra_base/db/model/scenario/scenario.py
@@ -288,6 +288,7 @@ class Scenario(Base, Inspect):
                 'created_by':rs.created_by,
                 'hidden':rs.hidden,
                 'value':rs.value if hasattr(rs, 'value') else None,
+                'value': getattr(rs, 'value', None)
                 'metadata':{},
             })
             rs_obj.resourceattr = rs_attr

--- a/hydra_base/db/model/scenario/scenario.py
+++ b/hydra_base/db/model/scenario/scenario.py
@@ -287,8 +287,7 @@ class Scenario(Base, Inspect):
                 'cr_date':rs.cr_date,
                 'created_by':rs.created_by,
                 'hidden':rs.hidden,
-                'value':rs.value if hasattr(rs, 'value') else None,
-                'value': getattr(rs, 'value', None)
+                'value': getattr(rs, 'value', None),
                 'metadata':{},
             })
             rs_obj.resourceattr = rs_attr

--- a/hydra_base/db/model/scenario/scenario.py
+++ b/hydra_base/db/model/scenario/scenario.py
@@ -127,6 +127,11 @@ class Scenario(Base, Inspect):
         ra_ids=None,
         include_results=True,
         include_only_results=False,
+        include_data_types=None,
+        exclude_data_types=None,
+        include_values=True,
+        include_data_type_values=None,
+        exclude_data_type_values=None,
         include_metadata=True):
         """
             Return all the resourcescenarios relevant to this scenario.
@@ -154,7 +159,13 @@ class Scenario(Base, Inspect):
             ra_ids=ra_ids,
             include_results=include_results,
             include_only_results=include_only_results,
-            include_metadata=include_metadata)
+            include_metadata=include_metadata,
+            include_data_types=include_data_types,
+            exclude_data_types=exclude_data_types,
+            include_values=include_values,
+            include_data_type_values=include_data_type_values,
+            exclude_data_type_values=exclude_data_type_values
+            )
 
         for this_rs in resourcescenarios:
             if this_rs.resource_attr_id not in childrens_ras:
@@ -171,11 +182,17 @@ class Scenario(Base, Inspect):
         ra_ids=None,
         include_results=True,
         include_only_results=False,
+        include_data_types=None,
+        exclude_data_types=None,
+        include_values=True,
+        include_data_type_values=None,
+        exclude_data_type_values=None,
         include_metadata=True):
         """
             Get all the resource scenarios in a network, across all scenarios
             returns a dictionary of dict objects, keyed on scenario_id
         """
+        log.debug("Starting dataset query")
 
         rs_qry = get_session().query(
                     Dataset.type,
@@ -185,7 +202,6 @@ class Scenario(Base, Inspect):
                     Dataset.cr_date,
                     Dataset.created_by,
                     Dataset.hidden,
-                    Dataset.value,
                     ResourceScenario.dataset_id,
                     ResourceScenario.scenario_id,
                     ResourceScenario.resource_attr_id,
@@ -211,13 +227,34 @@ class Scenario(Base, Inspect):
             rs_qry = rs_qry.filter(ResourceAttr.attr_is_var=='N')
 
         if include_only_results is True:
-            rs_qry = rs_qry.filter(ResourceAttr.attr_is_var=='Y')
+            rs_qry = rs_qry.filter(ResourceAttr.attr_is_var=='N')
 
         if ra_ids is not None:
             rs_qry = rs_qry.filter(ResourceScenario.resource_attr_id.in_(ra_ids))
+        
+        if include_data_types is not None:
+            rs_qry = rs_qry.filter(func.upper(Dataset.type).in_([t.upper() for t in include_data_types]))
+        
+        if exclude_data_types is not None:
+            rs_qry = rs_qry.filter(func.upper(Dataset.type).not_in([t.upper() for t in exclude_data_types]))
 
-        all_rs = rs_qry.all()
+        excl_values_rs = []
+        if include_values is True:
+            if include_data_type_values is not None:
+                rs_qry = rs_qry.filter(func.upper(Dataset.type).in_([t.upper() for t in include_data_type_values]))
 
+            if exclude_data_type_values is not None:
+                excl_values_qry = rs_qry.filter(func.upper(Dataset.type).in_([t.upper() for t in exclude_data_type_values]))
+                rs_qry = rs_qry.filter(func.upper(Dataset.type).not_in([t.upper() for t in exclude_data_type_values]))
+                excl_values_rs = excl_values_qry.all()
+
+            rs_qry = rs_qry.add_columns(Dataset.value)
+
+        non_dataframe_rs = rs_qry.all()
+        
+        all_rs = non_dataframe_rs + excl_values_rs
+
+        log.info(f"Ending dataset query -- {len(all_rs)} results")
         processed_rs = []
         for rs in all_rs:
             rs_obj = JSONObject({
@@ -250,7 +287,7 @@ class Scenario(Base, Inspect):
                 'cr_date':rs.cr_date,
                 'created_by':rs.created_by,
                 'hidden':rs.hidden,
-                'value':rs.value,
+                'value':rs.value if hasattr(rs, 'value') else None,
                 'metadata':{},
             })
             rs_obj.resourceattr = rs_attr

--- a/hydra_base/db/model/scenario/scenario.py
+++ b/hydra_base/db/model/scenario/scenario.py
@@ -227,7 +227,7 @@ class Scenario(Base, Inspect):
             rs_qry = rs_qry.filter(ResourceAttr.attr_is_var=='N')
 
         if include_only_results is True:
-            rs_qry = rs_qry.filter(ResourceAttr.attr_is_var=='N')
+            rs_qry = rs_qry.filter(ResourceAttr.attr_is_var=='Y')
 
         if ra_ids is not None:
             rs_qry = rs_qry.filter(ResourceScenario.resource_attr_id.in_(ra_ids))

--- a/hydra_base/lib/HydraTypes/Types.py
+++ b/hydra_base/lib/HydraTypes/Types.py
@@ -11,6 +11,7 @@ import math
 import six
 import numpy as np
 import pandas as pd
+from io import StringIO
 from abc import abstractmethod, abstractproperty
 from datetime import datetime
 import collections
@@ -224,7 +225,7 @@ class Dataframe(DataType):
                         longest_index = index
                 index = longest_index
 
-            df = pd.read_json(value, convert_axes=False)
+            df = pd.read_json(StringIO(value), convert_axes=False)
 
             #Make both indices the same type, so they can be compared
             df.index = df.index.astype(str)

--- a/hydra_base/lib/network.py
+++ b/hydra_base/lib/network.py
@@ -2638,7 +2638,13 @@ def get_all_resource_attributes_in_network(attr_id, network_id, include_resource
     return json_ra
 
 
-def get_all_resource_data(scenario_id, include_metadata=False, page_start=None, page_end=None, **kwargs):
+def get_all_resource_data(
+        scenario_id,
+        include_metadata=False,
+        page_start=None,
+        page_end=None,
+        include_values=True,
+        **kwargs):    
     """
         A function which returns the data for all resources in a network.
         -
@@ -2659,7 +2665,6 @@ def get_all_resource_data(scenario_id, include_metadata=False, page_start=None, 
                ResourceScenario.source,
                Dataset.id.label('dataset_id'),
                Dataset.name.label('dataset_name'),
-               Dataset.value,
                Dataset.unit_id,
                Dataset.hidden,
                Dataset.type,
@@ -2678,6 +2683,9 @@ def get_all_resource_data(scenario_id, include_metadata=False, page_start=None, 
                 outerjoin(ResourceGroup, ResourceAttr.group_id==ResourceGroup.id).\
                 outerjoin(Network, ResourceAttr.network_id==Network.id).\
             filter(ResourceScenario.scenario_id==scenario_id)
+
+    if include_values is True:
+        rs_qry = rs_qry.add_columns(Dataset.value)
 
     all_resource_data = rs_qry.all()
 

--- a/hydra_base/lib/project.py
+++ b/hydra_base/lib/project.py
@@ -355,6 +355,7 @@ def get_projects(uid, include_shared_projects=True, projects_ids_list_filter=Non
     nav_projects = []
     for nav_project_i in nav_projects_i:
         nav_project_j = JSONObject(nav_project_i)
+        nav_project_j.nav_only = True
         nav_project_j.owners = []
         nav_project_j.networks = []
         nav_projects.append(nav_project_j)

--- a/hydra_base/lib/scenario.py
+++ b/hydra_base/lib/scenario.py
@@ -1348,7 +1348,13 @@ def get_resource_data(ref_key, ref_id, scenario_id, type_id=None, expunge_sessio
     user_id = kwargs.get('user_id')
 
     resource_i = get_resource(ref_key, ref_id)
-    ra_ids = [ra.id for ra in resource_i.attributes]
+
+    resource_attributes = resource_i.get_attributes(
+        include_inputs = kwargs.get('include_inputs', True),
+        include_outputs = kwargs.get('include_outputs', True)
+    )
+    ra_ids = [ra.id for ra in resource_attributes]
+
     scenario_i = _get_scenario(scenario_id, user_id)
     requested_rs = scenario_i.get_data(user_id, get_parent_data=get_parent_data, ra_ids=ra_ids)
 

--- a/hydra_base/lib/scenario.py
+++ b/hydra_base/lib/scenario.py
@@ -1363,11 +1363,11 @@ def get_resource_data(ref_key,
             type_id (int): A filter which limits the resource scenarios to just the attributes defined by the resource type
             expunge_session (bool): Expunge the DB session -- means that modifying the results will not update the database. Default True
             get_parent_data (bool): Return the data of the parent scenario of the requestsed scenario in addition to the specified scenario. Default False.
-            include_inputs (bool) : Return resource scenarios which relate to resource attribtues where the attr_is_var=N. Default True
-            include_outputs (bool): Return resource scenarios which relate to resource attribtues where the attr_is_var=Y. Default True
+            include_inputs (bool) : Return resource scenarios which relate to resource attributes where the attr_is_var=N. Default True
+            include_outputs (bool): Return resource scenarios which relate to resource attributes where the attr_is_var=Y. Default True
             include_data_types (list(string)): Return only resource scenarios with a dataset that has the type of one of these specified data types. Default None, meaning no filter is applied.
             exclude_data_types (list(string)): Return resource scenarios with a dataset that do NOT have the type of one of these specified data types. Default None, meaning no filter is applied.
-            include_values (bool): Return the 'value' column of tDataset. Default True. Setting this to False can increase performance substantaally due to the size of some dataset values.
+            include_values (bool): Return the 'value' column of tDataset. Default True. Setting this to False can increase performance substantially due to the size of some dataset values.
             include_data_type_values (list(string)): When include_values is True, specify which dataset types should return with the value column included.
             exclude_data_type_values (list(string)): When include_values is True, specify which dataset types should return with the value column NOT included.
 

--- a/hydra_base/lib/scenario.py
+++ b/hydra_base/lib/scenario.py
@@ -1381,11 +1381,14 @@ def get_resource_data(ref_key,
 
     resource_attributes = resource_i.attributes
 
-    if include_inputs is True:
-        resource_attributes = list(filter(lambda x:x.attr_is_var=='N', resource_attributes))
-    
-    if include_outputs is True:
-        resource_attributes = list(filter(lambda x:x.attr_is_var=='Y', resource_attributes))
+    if include_inputs is False or include_outputs is False:
+        if include_inputs is False:
+            #only include outputs
+            resource_attributes = list(filter(lambda x:x.attr_is_var=='Y', resource_attributes))
+        
+        if include_outputs is False:
+            #only include inputs
+            resource_attributes = list(filter(lambda x:x.attr_is_var=='N', resource_attributes))
 
     ra_ids = [ra.id for ra in resource_attributes]
 

--- a/hydra_base/lib/scenario.py
+++ b/hydra_base/lib/scenario.py
@@ -1381,10 +1381,10 @@ def get_resource_data(ref_key,
 
     resource_attributes = resource_i.attributes
 
-    if include_inputs is True and include_outputs is False:
+    if include_inputs is True:
         resource_attributes = list(filter(lambda x:x.attr_is_var=='N', resource_attributes))
     
-    if include_outputs is True and include_inputs is False:
+    if include_outputs is True:
         resource_attributes = list(filter(lambda x:x.attr_is_var=='Y', resource_attributes))
 
     ra_ids = [ra.id for ra in resource_attributes]

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -901,18 +901,18 @@ class TestNetwork:
             for ra in group.attributes:
                 all_ras.append(ra.id)
 
-        all_resource_data = client.get_all_resource_data(s.id, include_values='N')
+        all_resource_data = client.get_all_resource_data(s.id, include_values=False)
         for rd in all_resource_data:
             assert rd.value is None
             assert int(rd.resource_attr_id) in all_ras
 
-        all_resource_data = client.get_all_resource_data(s.id, include_values='Y')
+        all_resource_data = client.get_all_resource_data(s.id, include_values=True)
         for rd in all_resource_data:
             assert rd.value is not None
             assert int(rd.resource_attr_id) in all_ras
 
 
-        truncated_resource_data = client.get_all_resource_data(s.id, include_values='Y', include_metadata='Y', page_start=0, page_end=1)
+        truncated_resource_data = client.get_all_resource_data(s.id, include_values=True, include_metadata=True, page_start=0, page_end=1)
         assert len(truncated_resource_data) == 1
 
     def test_get_resource_data(self, client, network_with_data):

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -931,48 +931,49 @@ class TestNetwork:
 
         all_node_types = list(set(all_node_types))
 
-        all_resource_data = client.get_resource_data('NODE', node.id,s.id, include_values=True)
-        for rd in all_resource_data:
-            assert rd.dataset.value is not None
-            assert int(rd.resource_attr_id) in node_ras
+        for datatype in all_node_types:
 
-        all_resource_data = client.get_resource_data('NODE', node.id,s.id,
-                                                     exclude_data_types=[all_node_types[0]],
-                                                     include_values=True)
-        for rd in all_resource_data:
-            # there should be no values returned with this type
-            assert rd.dataset.type != all_node_types[0] 
-            assert rd.dataset.value is not None
-            assert int(rd.resource_attr_id) in node_ras
-
-        all_resource_data = client.get_resource_data('NODE', node.id,s.id,
-                                                     include_data_types=[all_node_types[0]],
-                                                     include_values=True)
-        for rd in all_resource_data:
-            # there should be no values returned with this type
-            assert rd.dataset.type == all_node_types[0] 
-            assert rd.dataset.value is not None
-            assert int(rd.resource_attr_id) in node_ras
-
-        all_resource_data = client.get_resource_data('NODE', node.id,s.id,
-                                                     include_data_type_values=[all_node_types[0]],
-                                                     include_values=True)
-        for rd in all_resource_data:
-            if rd.dataset.type == all_node_types[0]:
+            all_resource_data = client.get_resource_data('NODE', node.id,s.id, include_values=True)
+            for rd in all_resource_data:
                 assert rd.dataset.value is not None
-            else:
-                assert rd.dataset.value is None
-            assert int(rd.resource_attr_id) in node_ras
+                assert int(rd.resource_attr_id) in node_ras
 
-        all_resource_data = client.get_resource_data('NODE', node.id,s.id,
-                                                     exclude_data_type_values=[all_node_types[0]],
-                                                     include_values=True)
-        for rd in all_resource_data:
-            if rd.dataset.type == all_node_types[0]:
-                assert rd.dataset.value is None
-            else:
+            all_resource_data = client.get_resource_data('NODE', node.id,s.id,
+                                                        exclude_data_types=[datatype],
+                                                        include_values=True)
+            for rd in all_resource_data:
+                assert rd.dataset.type != datatype 
                 assert rd.dataset.value is not None
-            assert int(rd.resource_attr_id) in node_ras
+                assert int(rd.resource_attr_id) in node_ras
+
+            all_resource_data = client.get_resource_data('NODE', node.id,s.id,
+                                                        include_data_types=[datatype],
+                                                        include_values=True)
+            for rd in all_resource_data:
+                assert rd.dataset.type == datatype 
+                assert rd.dataset.value is not None
+                assert int(rd.resource_attr_id) in node_ras
+
+            all_resource_data = client.get_resource_data('NODE', node.id,s.id,
+                                                        include_data_type_values=[datatype],
+                                                        include_values=True)
+            for rd in all_resource_data:
+                if rd.dataset.type == datatype:
+                    assert rd.dataset.value is not None
+                else:
+                    assert rd.dataset.value is None
+                assert int(rd.resource_attr_id) in node_ras
+
+            all_resource_data = client.get_resource_data('NODE', node.id,s.id,
+                                                        exclude_data_type_values=[datatype],
+                                                        include_values=True)
+            for rd in all_resource_data:
+                if rd.dataset.type == datatype:
+                    # there should be no values returned with this type
+                    assert rd.dataset.value is None
+                else:
+                    assert rd.dataset.value is not None
+                assert int(rd.resource_attr_id) in node_ras
 
     def test_delete_node(self, client, network_with_data):
         net = network_with_data


### PR DESCRIPTION
Add fitlers to the get_resourcedata function to enable more fine control over which values are returned. This is to improve performance, and does not affect default functionality