### PR TITLE
Fix issue with template cache returning a corrupt template

### DIFF
--- a/hydra_base/lib/template/__init__.py
+++ b/hydra_base/lib/template/__init__.py
@@ -298,8 +298,6 @@ def get_template_as_dict(template_id, **kwargs):
 
     output_data = {'attributes': attr_dict, 'datasets':dataset_dict, 'template': template_j}
 
-    _save_template_to_cache(template_j)
-
     return output_data
 
 @required_perms("add_template")


### PR DESCRIPTION
Don't store the template returned from _get_template_as_dict in the template cache, because it contains incorrect information, as it is designed to be downloaded as a file, and thus contains negative IDs.