### PR TITLE
232 unable to set the parent id of a project to none

### DIFF
--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -471,10 +471,18 @@ class TestProject:
             client.get_project(proj.id)
 
     def test_remove_project_parent(self, client, projectmaker, networkmaker):
+        """
+          Test two actions which should result in a project's parent_id
+          being set to None:
+            - Calling update_project() where the existing version has a not-None
+              parent_id while the argument's parent_id has been set to None
+            - Calling move_project() with a target parent project of None
+        """
         orig_parent_proj = projectmaker.create()
-        child_proj = projectmaker.create(parent_id=orig_parent_proj.id)
+        child_proj_update = projectmaker.create(parent_id=orig_parent_proj.id)
+        child_proj_move = projectmaker.create(parent_id=orig_parent_proj.id)
 
-        proj_i = client.get_project(child_proj.id)
+        proj_i = client.get_project(child_proj_update.id)
         assert proj_i.parent_id == orig_parent_proj.id
 
         # Remove parent of child_proj
@@ -482,5 +490,14 @@ class TestProject:
         client.update_project(proj_i)
 
         # Verify retrieved project now has no parent
-        proj_i = client.get_project(child_proj.id)
+        proj_i = client.get_project(child_proj_update.id)
+        assert proj_i.parent_id is None
+
+        proj_i = client.get_project(child_proj_move.id)
+        assert proj_i.parent_id == orig_parent_proj.id
+
+        client.move_project(child_proj_move.id, None)
+
+        # Verify moved project now has no parent
+        proj_i = client.get_project(child_proj_move.id)
         assert proj_i.parent_id is None

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -469,35 +469,3 @@ class TestProject:
         client.user_id = pytest.user_c.id
         with pytest.raises(hb.HydraError):
             client.get_project(proj.id)
-
-    def test_remove_project_parent(self, client, projectmaker, networkmaker):
-        """
-          Test two actions which should result in a project's parent_id
-          being set to None:
-            - Calling update_project() where the existing version has a not-None
-              parent_id while the argument's parent_id has been set to None
-            - Calling move_project() with a target parent project of None
-        """
-        orig_parent_proj = projectmaker.create()
-        child_proj_update = projectmaker.create(parent_id=orig_parent_proj.id)
-        child_proj_move = projectmaker.create(parent_id=orig_parent_proj.id)
-
-        proj_i = client.get_project(child_proj_update.id)
-        assert proj_i.parent_id == orig_parent_proj.id
-
-        # Remove parent of child_proj
-        proj_i.parent_id = None
-        client.update_project(proj_i)
-
-        # Verify retrieved project now has no parent
-        proj_i = client.get_project(child_proj_update.id)
-        assert proj_i.parent_id is None
-
-        proj_i = client.get_project(child_proj_move.id)
-        assert proj_i.parent_id == orig_parent_proj.id
-
-        client.move_project(child_proj_move.id, None)
-
-        # Verify moved project now has no parent
-        proj_i = client.get_project(child_proj_move.id)
-        assert proj_i.parent_id is None

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -95,7 +95,7 @@ class TestProject:
 
         new_project.description = \
             'An updated project created through the Hydra Base interface.'
-        
+
         new_project.appdata['test1'] = 'metadata1'
 
         updated_project = client.update_project(new_project)
@@ -249,7 +249,7 @@ class TestProject:
 
         proj_name = proj.name
 
-        #Set the status of the project to 'X'. 
+        #Set the status of the project to 'X'.
         client.set_project_status(proj.id, 'X')
         #now create a project with the name of the deleted project
         project = JSONObject({})
@@ -263,7 +263,7 @@ class TestProject:
         assert old_proj.status == 'X'
         assert old_proj.name != project.name
 
-        
+
 
     def test_clone_project(self, client, projectmaker, networkmaker):
 
@@ -348,9 +348,9 @@ class TestProject:
 
         client.user_id = recipient_user.id
         recipient_projects_before = client.get_projects(client.user_id)
-        
+
         client.user_id = sender_user_id
-        
+
         new_project_name = 'Cloned Project'
 
         test_delete_project_id = client.clone_project(
@@ -366,7 +366,7 @@ class TestProject:
         recipient_projects_after = client.get_projects(client.user_id)
 
         assert len(recipient_projects_after) == len(recipient_projects_before)+1
-        
+
         client.user_id = sender_user_id
         sender_projects_after = client.get_projects(client.user_id)
         assert len(sender_projects_after) == len(sender_projects_before)
@@ -383,7 +383,7 @@ class TestProject:
         cloned_networks = client.get_networks(cloned_project.id)
         assert len(cloned_networks) == 2
 
-        #Check that the resource attribute references have been updated correctly 
+        #Check that the resource attribute references have been updated correctly
         #by comparing the attr_id on the original network and the cloned network for the same attribute name,
         #ensuring they are not the same.
         for n in cloned_project.networks:
@@ -409,26 +409,26 @@ class TestProject:
 
         client.user_id = recipient_user.id
         recipient_projects_before = client.get_projects(client.user_id)
-        
+
         client.user_id = sender_user_id
-        
+
         new_project_name = 'Cloned Project Test'
 
         test_delete_project_id = client.clone_project(
             proj.id,
             recipient_user_id=recipient_user.id,
             new_project_name=new_project_name)
-        
+
         #test renaming of deleted projects
         client.set_project_status(test_delete_project_id, 'X')
         changed_project = client.get_project(test_delete_project_id)
         assert changed_project.status == 'X'
-        
+
         cloned_project_id = client.clone_project(
             proj.id,
             recipient_user_id=recipient_user.id,
             new_project_name=new_project_name)
-        
+
         renamed_project = client.get_project(test_delete_project_id)
         assert renamed_project.status == 'X'
 
@@ -469,3 +469,18 @@ class TestProject:
         client.user_id = pytest.user_c.id
         with pytest.raises(hb.HydraError):
             client.get_project(proj.id)
+
+    def test_remove_project_parent(self, client, projectmaker, networkmaker):
+        orig_parent_proj = projectmaker.create()
+        child_proj = projectmaker.create(parent_id=orig_parent_proj.id)
+
+        proj_i = client.get_project(child_proj.id)
+        assert proj_i.parent_id == orig_parent_proj.id
+
+        # Remove parent of child_proj
+        proj_i.parent_id = None
+        client.update_project(proj_i)
+
+        # Verify retrieved project now has no parent
+        proj_i = client.get_project(child_proj.id)
+        assert proj_i.parent_id is None

--- a/tests/project/test_project_inheritance.py
+++ b/tests/project/test_project_inheritance.py
@@ -348,3 +348,35 @@ class TestProjectInheritance:
         #User C can't see project 3
         with pytest.raises(HydraError):
             client.get_project(project_id=proj3.id)
+
+    def test_remove_project_parent(self, client, projectmaker, networkmaker):
+        """
+          Test two actions which should result in a project's parent_id
+          being set to None:
+            - Calling update_project() where the existing version has a not-None
+              parent_id while the argument's parent_id has been set to None
+            - Calling move_project() with a target parent project of None
+        """
+        orig_parent_proj = projectmaker.create()
+        child_proj_update = projectmaker.create(parent_id=orig_parent_proj.id)
+        child_proj_move = projectmaker.create(parent_id=orig_parent_proj.id)
+
+        proj_i = client.get_project(child_proj_update.id)
+        assert proj_i.parent_id == orig_parent_proj.id
+
+        # Remove parent of child_proj
+        proj_i.parent_id = None
+        client.update_project(proj_i)
+
+        # Verify retrieved project now has no parent
+        proj_i = client.get_project(child_proj_update.id)
+        assert proj_i.parent_id is None
+
+        proj_i = client.get_project(child_proj_move.id)
+        assert proj_i.parent_id == orig_parent_proj.id
+
+        client.move_project(child_proj_move.id, None)
+
+        # Verify moved project now has no parent
+        proj_i = client.get_project(child_proj_move.id)
+        assert proj_i.parent_id is None


### PR DESCRIPTION
Closes #232.

Adds `remove_project_parent()` to `lib/project.py` to set `parent_id` of project to `None`.  `move_project` and `update_project` now delegate to this in appropriate cases.

Test added to `tests/project/test_project_inheritance.py` verifies that `move_project` and `update_project` now allow parent removal.