### PR TITLE
Associate Rules with Networks, Projects or Templates

### DIFF
--- a/hydra_base/db/model/ownership.py
+++ b/hydra_base/db/model/ownership.py
@@ -18,7 +18,7 @@
 #
 from .base import *
 
-__all__ = ['ProjectOwner', 'NetworkOwner', 'RuleOwner', 'DatasetOwner']
+__all__ = ['ProjectOwner', 'NetworkOwner', 'DatasetOwner']
 
 class ProjectOwner(Base, Inspect):
     """
@@ -60,27 +60,6 @@ class NetworkOwner(Base, Inspect):
     network = relationship('Network', backref=backref('owners', order_by=user_id, uselist=True, cascade="all, delete-orphan"))
 
     _parents  = ['tNetwork', 'tUser']
-    _children = []
-
-class RuleOwner(AuditMixin, Base, Inspect):
-    """
-        This table tracks the owners of rules, to ensure rules which contain confidential logic
-        can be kept hidden
-    """
-
-    __tablename__='tRuleOwner'
-
-    user_id = Column(Integer(), ForeignKey('tUser.id'), primary_key=True, nullable=False)
-    rule_id = Column(Integer(), ForeignKey('tRule.id'), primary_key=True, nullable=False)
-    cr_date = Column(TIMESTAMP(),  nullable=False, server_default=text(u'CURRENT_TIMESTAMP'))
-    view = Column(String(1),  nullable=False, default='Y')
-    edit = Column(String(1),  nullable=False, default='N')
-    share = Column(String(1),  nullable=False, default='N')
-
-    user = relationship('User', foreign_keys=[user_id])
-    rule = relationship('Rule', backref=backref('owners', order_by=user_id, uselist=True, cascade="all, delete-orphan"))
-
-    _parents  = ['tRule', 'tUser']
     _children = []
 
 

--- a/hydra_base/db/model/rule.py
+++ b/hydra_base/db/model/rule.py
@@ -18,11 +18,9 @@
 #
 from .base import *
 
-from .ownership import RuleOwner
-
 __all__ = ['Rule', 'RuleTypeDefinition', 'RuleTypeLink']
 
-class Rule(AuditMixin, Base, Inspect, PermissionControlled):
+class Rule(AuditMixin, Base, Inspect):
     """
         A rule is an arbitrary piece of text applied to resources
         within a scenario. A scenario itself cannot have a rule applied
@@ -31,10 +29,9 @@ class Rule(AuditMixin, Base, Inspect, PermissionControlled):
 
     __tablename__ = 'tRule'
     __table_args__ = (
-        UniqueConstraint('scenario_id', 'name', name="unique rule name"),
+        UniqueConstraint('network_id', 'name', name="unique rule name"),
     )
 
-    __ownerclass__ = RuleOwner
     __ownerfk__ = 'rule_id'
 
     id = Column(Integer(), primary_key=True, nullable=False)
@@ -49,44 +46,28 @@ class Rule(AuditMixin, Base, Inspect, PermissionControlled):
     value = Column(Text().with_variant(mysql.LONGTEXT, 'mysql'), nullable=True)
 
     status = Column(String(1), nullable=False, server_default=text(u"'A'"))
-    scenario_id = Column(Integer(), ForeignKey('tScenario.id'), nullable=True)
 
     network_id = Column(Integer(), ForeignKey('tNetwork.id'), index=True, nullable=True)
-    node_id = Column(Integer(), ForeignKey('tNode.id'), index=True, nullable=True)
-    link_id = Column(Integer(), ForeignKey('tLink.id'), index=True, nullable=True)
-    group_id = Column(Integer(), ForeignKey('tResourceGroup.id'), index=True, nullable=True)
+    project_id = Column(Integer(), ForeignKey('tProject.id'), index=True, nullable=True)
+    template_id = Column(Integer(), ForeignKey('tTemplate.id'), index=True, nullable=True)
 
-    scenario = relationship('Scenario',
-                            backref=backref('rules',
-                                            uselist=True,
-                                            cascade="all, delete-orphan"),
-                            lazy='joined')
-    network = relationship('Network',
-                           backref=backref("rules",
+    network = relationship('Network', backref=backref("rules",
                                            order_by=network_id,
                                            cascade="all, delete-orphan"),
                            lazy='joined')
-    node = relationship('Node',
-                        backref=backref("rules",
-                                        order_by=node_id,
-                                        uselist=True,
-                                        cascade="all, delete-orphan"),
 
-                        lazy='joined')
-    link = relationship('Link',
-                        backref=backref("rules",
-                                        order_by=link_id,
-                                        uselist=True,
+    project = relationship('Project', backref=backref("rules",
+                                           order_by=project_id,
+                                           cascade="all, delete-orphan"),
+                           lazy='joined')
+    
+    template = relationship('Template', backref=backref("templates",
+                                        order_by=project_id,
                                         cascade="all, delete-orphan"),
                         lazy='joined')
-    group = relationship('ResourceGroup',
-                         backref=backref("rules",
-                                         order_by=group_id,#
-                                         uselist=True,
-                                         cascade="all, delete-orphan"),
-                         lazy='joined')
+    
 
-    _parents = ['tScenario', 'tNode', 'tLink', 'tProject', 'tNetwork', 'tResourceGroup']
+    _parents = ['tProject', 'tNetwork', 'tTemplate']
     _children = []
 
 

--- a/hydra_base/db/model/rule.py
+++ b/hydra_base/db/model/rule.py
@@ -136,9 +136,6 @@ class Rule(AuditMixin, Base, Inspect):
         if self.project:
             rule_owners += self.project.get_owners()
 
-        if self.template:
-            rule_owners += self.template.get_owners()
-
         user_ids = set(o.user_id for o in rule_owners)
         return [{"user_id": user_id} for user_id in user_ids]
 

--- a/hydra_base/db/model/template.py
+++ b/hydra_base/db/model/template.py
@@ -290,6 +290,13 @@ class Template(Base, Inspect):
 
         return child_types
 
+    def get_hierarchy(self, user_id):
+
+        hierarchy = [JSONObject(self)]
+        if self.parent_id:
+            hierarchy = hierarchy + self.parent.get_hierarchy(user_id)
+        return hierarchy
+
 class TemplateType(Base, Inspect):
     """
     Template Type

--- a/hydra_base/lib/network.py
+++ b/hydra_base/lib/network.py
@@ -3166,34 +3166,6 @@ def _clone_rules(old_network_id, new_network_id, node_id_map, link_id_map, group
                                scenario_id_map=scenario_id_map,
                                user_id=user_id)
 
-    node_rules = db.DBSession.query(Rule).join(Node).filter(Node.network_id==old_network_id).all()
-    for node_rule in node_rules:
-        rules.clone_rule(node_rule.id,
-                         target_ref_key='NODE',
-                         target_ref_id=node_id_map[node_rule.node_id],
-                         scenario_id_map=scenario_id_map,
-                         user_id=user_id)
-
-    link_rules = db.DBSession.query(Rule).join(Link).filter(Link.network_id==old_network_id).all()
-
-    for link_rule in link_rules:
-        rules.clone_rule(link_rule.id,
-                         target_ref_key='LINK',
-                         target_ref_id=link_id_map[link_rule.link_id],
-                         scenario_id_map=scenario_id_map,
-                         user_id=user_id)
-
-    group_rules = db.DBSession.query(Rule).join(ResourceGroup).filter(ResourceGroup.network_id==old_network_id).all()
-
-    for group_rule in group_rules:
-        rules.clone_rule(group_rule.id,
-                         group_rule.node_id,
-                         target_ref_key='GROUP',
-                         target_ref_id=group_id_map[group_rule.group_id],
-                         scenario_id_map=scenario_id_map,
-                         user_id=user_id)
-
-
 def _clone_nodes(old_network_id, new_network_id, user_id):
 
     nodes = db.DBSession.query(Node).filter(Node.network_id==old_network_id).all()

--- a/hydra_base/lib/objects.py
+++ b/hydra_base/lib/objects.py
@@ -50,6 +50,11 @@ class JSONObject(dict):
     """
     def __init__(self, obj_dict={}, parent=None, extras={}):
 
+        if hasattr(obj_dict, "asdict") and obj_dict.asdict is not None:
+            rd = obj_dict.asdict()
+            for k, v in rd.items():
+                setattr(self, k, v)
+
         if isinstance(obj_dict, six.string_types):
             try:
                 obj = json.loads(obj_dict)

--- a/hydra_base/lib/rules.py
+++ b/hydra_base/lib/rules.py
@@ -102,11 +102,12 @@ def get_template_rules(template_id, summary=True, **kwargs):
     template = db.DBSession.query(Template).filter(Template.id==template_id).one()
     rule_qry = db.DBSession.query(Rule).filter(Rule.status != 'X')
 
-    all_template_rules = []
-    template_hierarchy = template.get_hierarchy().reverse()
-    for current_template in template_hierarchy:
-        this_template_rules = rule_qry.filter(Rule.template_id == current_template.id).all()
-        all_template_rules = all_template_rules + this_template_rules
+    all_template_rules = rule_qry.filter(Rule.template_id == template_id).all()
+    template_hierarchy = template.get_hierarchy(**kwargs).reverse()
+    if template_hierarchy is not None:
+        for current_template in template_hierarchy:
+            this_template_rules = rule_qry.filter(Rule.template_id == current_template.id).all()
+            all_template_rules = all_template_rules + this_template_rules
 
     if summary is False:
         for rule in all_template_rules:

--- a/hydra_base/lib/rules.py
+++ b/hydra_base/lib/rules.py
@@ -92,7 +92,7 @@ def get_network_rules(network_id, summary=True, **kwargs):
     return all_network_rules
 
 
-@required_perms("get_network", "get_rules")
+@required_perms("get_rules")
 def get_resource_rules(ref_key, ref_id, scenario_id=None, **kwargs):
     """
         Get all the rules for a given resource.
@@ -132,7 +132,7 @@ def get_resource_rules(ref_key, ref_id, scenario_id=None, **kwargs):
 
     return rules
 
-@required_perms("get_network", "get_rules")
+@required_perms("get_rules")
 def get_rules_of_type(typecode, scenario_id=None, **kwargs):
     """
         Get all the rules for a given resource.
@@ -159,7 +159,7 @@ def get_rules_of_type(typecode, scenario_id=None, **kwargs):
 
     return rules
 
-@required_perms("get_network", "get_rules")
+@required_perms("get_rules")
 def get_rule(rule_id, **kwargs):
     """
         Get a rule by its ID
@@ -172,16 +172,16 @@ def get_rule(rule_id, **kwargs):
     rule = _get_rule(rule_id, user_id)
     return rule
 
-@required_perms("edit_network", "add_rules")
-def add_rules(rules, include_network_users=True, **kwargs):
+@required_perms("add_rules")
+def add_rules(rules, **kwargs):
     LOG.info("Adding %s rules."%len(rules))
     for rule in rules:
-        add_rule(rule, include_network_users=include_network_users, **kwargs)
+        add_rule(rule, **kwargs)
 
     LOG.info("Rules Added")
 
-@required_perms("edit_network", "add_rules")
-def add_rule(rule, include_network_users=True, **kwargs):
+@required_perms("add_rules")
+def add_rule(rule, **kwargs):
     """
         Add a new rule.
         Args:
@@ -216,7 +216,7 @@ def add_rule(rule, include_network_users=True, **kwargs):
 
     return rule_i
 
-@required_perms("edit_network", "update_rules")
+@required_perms("update_rules")
 def update_rule(rule, **kwargs):
     """
         Add a new rule.
@@ -252,7 +252,7 @@ def update_rule(rule, **kwargs):
 
     return rule_i
 
-@required_perms("edit_network", "update_rules")
+@required_perms("update_rules")
 def set_rule_type(rule_id, typecode, **kwargs):
     """
         Assign a rule type to a rule
@@ -277,7 +277,7 @@ def set_rule_type(rule_id, typecode, **kwargs):
     return rule_i
 
 @required_perms("edit_network", "get_rules", "add_rules")
-def clone_resource_rules(ref_key, ref_id, target_ref_key=None, target_ref_id=None, scenario_id_map={}, **kwargs):
+def clone_resource_rules(ref_key, ref_id, target_ref_key=None, target_ref_id=None, **kwargs):
     """
         Clone a rule
         args:
@@ -287,9 +287,6 @@ def clone_resource_rules(ref_key, ref_id, target_ref_key=None, target_ref_id=Non
                                      different resource, specify the new resources type
             target_ref_id (int): If the rule is to be cloned into a different
                                  resources, specify the resource ID.
-            scenario_id_map (dict): If the old rule is specified in a scenario,
-                                    then provide a dictionary mapping from the
-                                    old scenario ID to the new one, like {123 : 456}
 
         Cloning will only occur into a different resource if both
         ref_key AND ref_id are provided. Otherwise it will maintain its
@@ -310,7 +307,6 @@ def clone_resource_rules(ref_key, ref_id, target_ref_key=None, target_ref_id=Non
                                        target_ref_key=target_ref_key,
                                        target_ref_id=target_ref_id,
                                        user_id=user_id))
-
 
     return cloned_rules
 
@@ -360,7 +356,7 @@ def clone_rule(rule_id, target_ref_key=None, target_ref_id=None, **kwargs):
 
     return cloned_rule
 
-@required_perms("edit_network", "update_rules")
+@required_perms("update_rules")
 def delete_rule(rule_id, **kwargs):
     """
         Set the status of a rule to 'X'
@@ -377,7 +373,7 @@ def delete_rule(rule_id, **kwargs):
 
     db.DBSession.flush()
 
-@required_perms("edit_network", "update_rules")
+@required_perms("update_rules")
 def activate_rule(rule_id, **kwargs):
     """
         Set the status of a rule to 'A'
@@ -394,7 +390,7 @@ def activate_rule(rule_id, **kwargs):
 
     db.DBSession.flush()
 
-@required_perms("edit_network", "delete_rules")
+@required_perms("delete_rules")
 def purge_rule(rule_id, **kwargs):
     """
         Remove a rule from the DB permanently
@@ -410,7 +406,7 @@ def purge_rule(rule_id, **kwargs):
     db.DBSession.delete(rule_i)
     db.DBSession.flush()
 
-@required_perms("edit_network", "update_rules")
+@required_perms("update_rules")
 def add_rule_type_definition(ruletypedefinition, **kwargs):
     """
         Add a rule type definition
@@ -440,7 +436,7 @@ def add_rule_type_definition(ruletypedefinition, **kwargs):
     else:
         return existing_rtd
 
-@required_perms("edit_network", "get_rules")
+@required_perms("get_rules")
 def get_rule_type_definitions(**kwargs):
     """
         Get all rule types
@@ -453,7 +449,7 @@ def get_rule_type_definitions(**kwargs):
 
     return all_rule_type_definitions_i
 
-@required_perms("edit_network", "get_rules")
+@required_perms("get_rules")
 def get_rule_type_definition(typecode, **kwargs):
     """
         Get a Type with the given typecode
@@ -472,7 +468,7 @@ def get_rule_type_definition(typecode, **kwargs):
 
     return rule_type_definition_i
 
-@required_perms("edit_network", "update_rules")
+@required_perms("update_rules")
 def purge_rule_type_definition(typecode, **kwargs):
     """
         Delete a rule type from the DB. Doing this will revert all existing rules to

--- a/hydra_base/lib/sharing.py
+++ b/hydra_base/lib/sharing.py
@@ -90,8 +90,6 @@ def share_network(network_id, usernames, read_only, share, **kwargs):
         #Set the owner ship on the network itself
         net_i.set_owner(user_i.id, write=write, share=share)
 
-        for rule_i in net_i.rules:
-            rule_i.set_owner(user_i.id, write=write, share=share)
         Project.clear_cache(user_i.id)
     db.DBSession.flush()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ pandas
 numpy
 bcrypt
 lxml
-mysql-client
 pymongo
 mysqlclient
 pudb

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -267,11 +267,15 @@ class TestRules:
 
         ret_rules = client.get_project_rules(project.id)
 
-        for rule in ret_rules:
-            assert rule.id == new_rule_j.id
-            assert rule.name == new_rule_j.name
-            assert rule.value == new_rule_j.value
+        assert ret_rules[0].id == new_rule_j.id
+        assert ret_rules[0].name == new_rule_j.name
+        assert ret_rules[0].value == new_rule_j.value
 
+        res_ret_rules = client.get_resource_rules("PROJECT", project.id)
+
+        assert res_ret_rules[0].id == new_rule_j.id
+        assert res_ret_rules[0].name == new_rule_j.name
+        assert res_ret_rules[0].value == new_rule_j.value
 
     def test_update_rule(self, client, network_with_data):
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -248,6 +248,30 @@ class TestRules:
         assert len(proj_cloned_rule.types) == 1
 
 
+    def test_project_rule(self, client, projectmaker):
+        project = projectmaker.create("Rule Parent Project")
+        ruletype_A_j = client.add_rule_type_definition(JSONObject({'name':'A new Rule', 'code':'a_new_rule'}))
+        rulename = "Rule 001"
+        ruletext = "int(1)"
+        new_rule_j = self.add_rule(client,
+                                   target=project,
+                                   ref_key="PROJECT",
+                                   ref_id=project.id,
+                                   name=rulename,
+                                   text=ruletext,
+                                   types=[ruletype_A_j.code])
+
+        assert new_rule_j.id is not None
+        assert new_rule_j.name == rulename
+        assert new_rule_j.value == ruletext
+
+        ret_rules = client.get_project_rules(project.id)
+
+        for rule in ret_rules:
+            assert rule.id == new_rule_j.id
+            assert rule.name == new_rule_j.name
+            assert rule.value == new_rule_j.value
+
 
     def test_update_rule(self, client, network_with_data):
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -26,6 +26,8 @@ from hydra_base.exceptions import HydraError, PermissionError
 from hydra_base.lib.objects import JSONObject, Dataset
 from hydra_base.util.hydra_dateutil import timestamp_to_ordinal
 
+from .templates.test_templates import template, template_json_object
+
 import logging
 log = logging.getLogger(__name__)
 
@@ -401,3 +403,26 @@ class TestRules:
 
         #check all the rules are still there
         assert len(client.get_resource_rules('NETWORK', network_with_data.id)) == 3
+
+    def test_template_rules(self, client, template_json_object):
+        rulename = "Rule 001"
+        ruletext = "int(1)"
+        new_rule = self.add_rule(client,
+                                   target=template_json_object,
+                                   ref_key="TEMPLATE",
+                                   ref_id=template_json_object.id,
+                                   name=rulename,
+                                   text=ruletext)
+
+        # Has Rule been added and returned correctly?
+        assert new_rule.id is not None
+        assert new_rule.name == rulename
+        assert new_rule.value == ruletext
+
+        # Is Rule added to and retrievable from correct Template?
+        ret_rules = client.get_template_rules(template_json_object.id)
+
+        assert len(ret_rules) == 1
+        assert ret_rules[0].id == new_rule.id
+        assert ret_rules[0].name == new_rule.name
+        assert ret_rules[0].value == new_rule.value

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -31,8 +31,8 @@ log = logging.getLogger(__name__)
 
 class TestRules:
 
-    def add_rule(self, client, network, name='A Test Rule', text='e=mc^2',
-                 scenario_id=None, ref_key=None, ref_id=None, types=[]):
+    def add_rule(self, client, target=None, name='A Test Rule', text='e=mc^2',
+                 ref_key=None, ref_id=None, types=[]):
         """
             A utility function which creates a rule and associates it
             with either a resource type, resource instance or resource
@@ -42,16 +42,13 @@ class TestRules:
         rule = JSONObject({
             'name'        : name,
             'value'       : text,
-            'scenario_id' : scenario_id,
-            'ref_key'     : 'NETWORK' if ref_key is None else ref_key,
-            'ref_id'      : network.id if ref_id is None else ref_id,
+            'ref_key'     : "NETWORK" if ref_key is None else ref_key,
+            'ref_id'      : target.id if ref_id is None else ref_id,
             'types'       : [{'code':typecode} for typecode in types]
         })
 
-        new_rule_j = JSONObject(client.add_rule(scenario_id=None,
-                                                rule=rule,
-                                                include_network_users=True))
-
+        c_rule = client.add_rule(rule=rule)
+        new_rule_j = JSONObject(c_rule)
         return new_rule_j
 
     def test_add_rule_type_definition(self, client):
@@ -98,25 +95,6 @@ class TestRules:
 
         net_rule_j = self.add_rule(client, network_with_data)
 
-        #add a rule to a node to ensure cloning of node-level rules are also working
-        ##sort the nodes here to ensure we can identify the matching node in the cloned network
-        node_rule_no_scenario_j = self.add_rule(client,
-                                                network_with_data,
-                                                ref_key='NODE',
-                                                ref_id=sorted(network_with_data.nodes, key=lambda x: x.name)[0].id,
-                                                text="Node rule no scenario")
-
-        #add a rule to a node AND a scenario to ensure cloning of node-level rules are working with scenarios.
-        #The new rule should have the ID of the new scenario
-        node_rule_with_scenario_j = self.add_rule(client,
-                                                  network_with_data,
-                                                  ref_key='NODE',
-                                                  ref_id=sorted(network_with_data.nodes, key=lambda x: x.name)[0].id,
-                                                  scenario_id=network_with_data.scenarios[0].id,
-                                                  text='Scenario Node Rule')
-        #sanity check
-        assert node_rule_with_scenario_j.scenario_id == network_with_data.scenarios[0].id
-
         cloned_network_id = client.clone_network(network_with_data.id)
 
         cloned_network = client.get_network(cloned_network_id)
@@ -124,17 +102,6 @@ class TestRules:
         network_rules = client.get_resource_rules('NETWORK', cloned_network.id)
         assert len(network_rules) == 1
         assert network_rules[0].value == net_rule_j.value;
-
-        #sorted the nodes here to ensure we identified the matching node from the original network
-        sorted_nodes = sorted(cloned_network.nodes, key=lambda x: x.name)
-        node_rules = sorted(client.get_resource_rules('NODE', sorted_nodes[0].id), key=lambda x:x.value)
-        assert len(node_rules) == 2
-        assert node_rules[0].scenario_id == None
-        assert node_rules[0].value == node_rule_no_scenario_j.value
-
-        #sorted the nodes here to ensure we identified the matching node from the original network
-        assert node_rules[1].scenario_id == cloned_network.scenarios[0].id
-        assert node_rules[1].value == node_rule_with_scenario_j.value
 
     def test_share_network_with_rules(self, client, network_with_data):
 
@@ -168,16 +135,13 @@ class TestRules:
         #Create 3 rules, 2 of type A and 1 of type B
         self.add_rule(client, network_with_data, name="Test1", types=[ruletype_A_j.code])
         self.add_rule(client, network_with_data, name="Test2", types=[ruletype_A_j.code])
-        self.add_rule(client, network_with_data, name="Test3", types=[ruletype_A_j.code, ruletype_B_j.code],
-                      scenario_id=scenario_id)
+        self.add_rule(client, network_with_data, name="Test3", types=[ruletype_A_j.code, ruletype_B_j.code])
         self.add_rule(client, network_with_data, name="Rule Type B", types=[ruletype_B_j.code])
 
         #Get all the rules of type A, of which there should be 2
         rules_of_type = client.get_rules_of_type(ruletype_A_j.code)
-        rules_of_type_in_scenario = client.get_rules_of_type(ruletype_A_j.code, scenario_id=scenario_id)
 
         assert len(rules_of_type) == 3
-        assert len(rules_of_type_in_scenario) == 1
 
     def test_add_rule_type(self, client, network_with_data):
         ruletype_A_j = client.add_rule_type_definition(JSONObject({'name':'A new Rule', 'code':'a_new_rule'}))
@@ -188,16 +152,14 @@ class TestRules:
         #Create 3 rules, 2 of type A and 1 of type B
         self.add_rule(client, network_with_data, name="Test1", types=[ruletype_A_j.code])
         self.add_rule(client, network_with_data, name="Test2", types=[ruletype_A_j.code])
-        rule3 = self.add_rule(client, network_with_data, name="Test3", types=[ruletype_A_j.code], scenario_id=scenario_id)
+        rule3 = self.add_rule(client, network_with_data, name="Test3", types=[ruletype_A_j.code])
 
         #Get all the rules of type A, of which there should be 2
         rules_of_type = client.get_rules_of_type(ruletype_A_j.code)
-        rules_of_type_in_scenario = client.get_rules_of_type(ruletype_A_j.code, scenario_id=scenario_id)
 
         assert len(rules_of_type) >= 3
         #CHeck that the added nodes are indeed present
         assert {'Test1', 'Test2', 'Test3'}.issubset({r.name for r in rules_of_type})
-        assert len(rules_of_type_in_scenario) == 1
 
         client.set_rule_type(rule3.id, ruletype_B_j.code)
 
@@ -225,7 +187,7 @@ class TestRules:
         assert len(rule_network.owners) == len(new_rule_j.owners)
 
 
-    def test_clone_rule(self, client, network_with_data):
+    def test_clone_rule(self, client, network_with_data, projectmaker):
 
         ruletype_A_j = client.add_rule_type_definition(JSONObject({'name':'A new Rule', 'code':'a_new_rule'}))
         ruletype_B_j = client.add_rule_type_definition(JSONObject({'name':'A new Rule 1', 'code':'a_new_rule_1'}))
@@ -233,7 +195,7 @@ class TestRules:
         rulename = 'Added Rule'
         ruletext = 'e=mc^3'#yes this is delibrate, so it's different to the default
         new_rule_j = self.add_rule(client,
-                                   network_with_data,
+                                   target=network_with_data,
                                    name=rulename,
                                    text=ruletext,
                                    types=[ruletype_A_j.code, ruletype_B_j.code])
@@ -242,7 +204,16 @@ class TestRules:
         assert new_rule_j.name == rulename
         assert new_rule_j.value == ruletext
 
-        cloned_rule = client.clone_rule(new_rule_j.id)
+        project = projectmaker.create('Target Network Parent')
+        network = JSONObject()
+        network.name = f"New network {datetime.datetime.now()}"
+        network.description = "Clone rule target network"
+        network.project_id = project.id
+
+        target_network = client.add_network(network)
+
+        # Clone to rule to new network
+        cloned_rule = client.clone_rule(new_rule_j.id, target_ref_key="NETWORK", target_ref_id=target_network.id)
 
         assert cloned_rule.name == new_rule_j.name
         assert cloned_rule.value == new_rule_j.value
@@ -250,6 +221,32 @@ class TestRules:
         assert cloned_rule.id != new_rule_j.id
         assert len(cloned_rule.types) == 2
         assert [t.code for t in new_rule_j.types] == [t.code for t in cloned_rule.types]
+
+        # Clone rule to new project
+        src_proj = projectmaker.create("Rule Source Project")
+        dest_proj = projectmaker.create("Rule Destination Project")
+
+
+        proj_rulename = "Project Rule"
+        proj_ruletext = "e=mc^3"
+        proj_rule = self.add_rule(client,
+                                  name=proj_rulename,
+                                  text=proj_ruletext,
+                                  types=[ruletype_A_j.code],
+                                  ref_key="PROJECT",
+                                  ref_id=project.id)
+
+        proj_cloned_rule = client.clone_rule(
+                             proj_rule.id,
+                             target_ref_key="PROJECT",
+                             target_ref_id=dest_proj.id)
+
+        assert proj_cloned_rule.name == proj_rule.name
+        assert proj_cloned_rule.value == proj_rule.value
+        assert proj_cloned_rule.id is not None
+        assert proj_cloned_rule.id != proj_rule.id
+        assert len(proj_cloned_rule.types) == 1
+
 
 
     def test_update_rule(self, client, network_with_data):
@@ -284,14 +281,6 @@ class TestRules:
         assert updated_rule_j.scenario_id is None
         assert len(updated_rule_j.types) == 2
 
-        #update the rule again, setting it on a scenario
-        updated_rule_j.scenario_id = network_with_data.scenarios[0].id
-
-        client.update_rule(updated_rule_j)
-
-        updated_rule_j_2 = client.get_rule(updated_rule_j.id)
-
-        assert updated_rule_j_2.scenario_id == network_with_data.scenarios[0].id
 
     def test_add_rule_with_type(self, client, network_with_data):
 
@@ -312,49 +301,6 @@ class TestRules:
 
 
         assert new_rule_j.id in [r.id for r in client.get_rules_of_type(typecode)]
-
-
-    def test_add_rule_to_scenario(self, client, network_with_data):
-
-        client.add_rule_type_definition(JSONObject({'name':'A new Rule', 'code':'a_new_rule'}))
-
-        scenario_id = network_with_data.scenarios[0].id
-
-        new_rule_a_j = self.add_rule(client, network_with_data, name='Added Rule', text='e=mc^3')
-        new_rule_b_j = self.add_rule(client, network_with_data, name='Added Rule 1', text='e=mc^4')
-
-        new_rule_c_j = self.add_rule(client, network_with_data, scenario_id=scenario_id, name='Added Rule 2', text='e=mc^5')
-
-        scenario_rules = client.get_scenario_rules(scenario_id)
-        resource_rules = client.get_resource_rules('NETWORK', network_with_data.id)
-        resource_rules_with_scenario = client.get_resource_rules('NETWORK', network_with_data.id, scenario_id=scenario_id)
-
-        assert len(scenario_rules) == 1
-        assert scenario_rules[0].name == new_rule_c_j.name
-        assert len(resource_rules) >= 3
-        assert {r.name for r in (new_rule_a_j, new_rule_b_j, new_rule_c_j)}.issubset({r.name for r in resource_rules})
-        assert len(resource_rules_with_scenario) == 1
-        assert resource_rules_with_scenario[0].name == new_rule_c_j.name
-
-    def test_add_rule_to_node(self, client, network_with_data):
-        scenario_id = network_with_data.scenarios[0].id
-        node_id = network_with_data.nodes[0].id
-
-        new_rule_a_j = self.add_rule(client, network_with_data, ref_key='NODE', ref_id=node_id, name='Added Rule', text='e=mc^3')
-        new_rule_b_j = self.add_rule(client, network_with_data, ref_key='NODE', ref_id=node_id, name='Added Rule 1', text='e=mc^4')
-        new_rule_c_j = self.add_rule(client, network_with_data, ref_key='NODE', ref_id=node_id, scenario_id=scenario_id, name='Added Rule 2', text='e=mc^5')
-
-        scenario_rules = client.get_scenario_rules(scenario_id)
-        all_resource_rules = client.get_resource_rules('NODE', node_id)
-        resource_rules_with_scenario = client.get_resource_rules('NODE', node_id, scenario_id=scenario_id)
-
-        assert len(scenario_rules) == 1
-        assert scenario_rules[0].name == new_rule_c_j.name
-        assert len(all_resource_rules) >= 3
-        assert sorted([r.name for r in all_resource_rules]) == sorted([r.name for r in (new_rule_a_j, new_rule_b_j, new_rule_c_j)])
-        assert len(resource_rules_with_scenario) == 1
-        assert resource_rules_with_scenario[0].name == new_rule_c_j.name
-
 
     def test_delete_rule(self, client, network_with_data):
 
@@ -412,21 +358,18 @@ class TestRules:
         #Create 3 rules, 2 of type A and 1 of type B
         self.add_rule(client, network_with_data, name="Test1", types=[ruletype_A_j.code])
         self.add_rule(client, network_with_data, name="Test2", types=[ruletype_A_j.code])
-        self.add_rule(client, network_with_data, name="Test3", types=[ruletype_A_j.code, ruletype_B_j.code], scenario_id=scenario_id)
         self.add_rule(client, network_with_data, name="Rule Type B", types=[ruletype_B_j.code])
 
         #Get all the rules of type A, of which there should be 2
         rules_of_type = client.get_rules_of_type(ruletype_A_j.code)
-        rules_of_type_in_scenario = client.get_rules_of_type(ruletype_A_j.code, scenario_id=scenario_id)
 
-        assert len(rules_of_type) >= 3
+        assert len(rules_of_type) >= 2
         #Check that the added nodes are indeed present
-        assert {'Test1', 'Test2', 'Test3'}.issubset({r.name for r in rules_of_type})
-        assert len(rules_of_type_in_scenario) == 1
+        assert {'Test1', 'Test2'}.issubset({r.name for r in rules_of_type})
 
         client.purge_rule_type_definition('a_new_rule')
 
         assert len(client.get_rules_of_type(ruletype_A_j.code)) == 0
 
         #check all the rules are still there
-        assert len(client.get_resource_rules('NETWORK', network_with_data.id)) == 4
+        assert len(client.get_resource_rules('NETWORK', network_with_data.id)) == 3


### PR DESCRIPTION
Associates Rules with Networks, Projects or Templates and moves permissions checking to those resources.  Removes concept of Rules associated with resources within networks, such as Nodes or Groups.

Rule type-specific `check_read/write_permission()` methods replace those provided by the `PermissionControlled` mixin.