### PR TITLE
Replace winpath with ctypes

### DIFF
--- a/doc/tutorials/getting-started/server.rst
+++ b/doc/tutorials/getting-started/server.rst
@@ -1,4 +1,4 @@
-How to run the server natively on Windows Using python. 
+How to run the server natively on Windows Using python.
 =======================================================
 
 The soap server runs in python (2.7), and requires some external
@@ -156,15 +156,15 @@ SqlAlchemy
 Try:
 `pip install sqlalchemy`
 
-We use sqlalchemy to provide database connections and manage the database communication.  
+We use sqlalchemy to provide database connections and manage the database communication.
 
 zope.sqlalchemy
 ***************
 Try:
 `pip install zope.sqlalchemy`
 
-The aim of this package is to unify the plethora of existing packages integrating 
-SQLAlchemy with Zope's transaction management. As such it seeks only to provide 
+The aim of this package is to unify the plethora of existing packages integrating
+SQLAlchemy with Zope's transaction management. As such it seeks only to provide
 a data manager and makes no attempt to define a zopeish way to configure engines.
 
 Pandas
@@ -173,13 +173,6 @@ Try:
 `pip install pandas`
 
 Pandas allows us to manipulate and store timeseries and arrays in a very efficient and flexible way.
-
-winpath
-********
-Try:
-`pip install winpath`
-
-winpath is a python module that retrieves the names of common Windows folders.
 
 CherryPy
 *********
@@ -190,7 +183,7 @@ CherryPy allows developers to build web applications in much the same way they w
 
 python-dateutil
 ****************
-Try: 
+Try:
 `pip install python-dateutil`
 
 The dateutil module provides powerful extensions to the standard datetime module.

--- a/hydra_base/config.py
+++ b/hydra_base/config.py
@@ -75,12 +75,12 @@ def load_config():
     repofile = os.path.join(modulepath, 'hydra.ini')
     repofiles = glob.glob(repofile)
 
-    if os.name == 'nt':
-        import winpath
+    if sys.platform.startswith("win"):
+        from hydra_base.util.windows import win_get_common_documents
         userfile = os.path.join(os.path.expanduser('~'),'AppData','Local','hydra.ini')
         userfiles = glob.glob(userfile)
 
-        sysfile = os.path.join(winpath.get_common_documents(), 'Hydra','hydra.ini')
+        sysfile = os.path.join(win_get_common_documents(), 'Hydra','hydra.ini')
         sysfiles = glob.glob(sysfile)
     else:
         userfile = os.path.join(os.path.expanduser('~'), '.hydra', 'hydra.ini')
@@ -110,9 +110,6 @@ def load_config():
         else:
             logging.warning('HYDRA_CONFIG set as %s but file does not exist', env_value)
 
-
-    if os.name == 'nt':
-        set_windows_env_variables(config)
 
     try:
         home_dir = config.get('DEFAULT', 'home_dir')
@@ -145,28 +142,6 @@ def read_values_from_environment(config, section_key, options_key):
         # print("Presente")
         config.set(section_key, options_key, env_value)
 
-
-def set_windows_env_variables(config):
-    import winpath
-    config.set('DEFAULT', 'common_app_data_folder', winpath.get_common_appdata())
-    config.set('DEFAULT', 'win_local_appdata', winpath.get_local_appdata())
-    config.set('DEFAULT', 'win_appdata', winpath.get_appdata())
-    config.set('DEFAULT', 'win_desktop', winpath.get_desktop())
-    config.set('DEFAULT', 'win_programs', winpath.get_programs())
-    config.set('DEFAULT', 'win_common_admin_tools', winpath.get_common_admin_tools())
-    config.set('DEFAULT', 'win_common_documents', winpath.get_common_documents())
-    config.set('DEFAULT', 'win_cookies', winpath.get_cookies())
-    config.set('DEFAULT', 'win_history', winpath.get_history())
-    config.set('DEFAULT', 'win_internet_cache', winpath.get_internet_cache())
-    config.set('DEFAULT', 'win_my_pictures', winpath.get_my_pictures())
-    config.set('DEFAULT', 'win_personal', winpath.get_personal())
-    config.set('DEFAULT', 'win_my_documents', winpath.get_my_documents())
-    config.set('DEFAULT', 'win_program_files', winpath.get_program_files())
-    config.set('DEFAULT', 'win_program_files_common', winpath.get_program_files_common())
-    config.set('DEFAULT', 'win_system', winpath.get_system())
-    config.set('DEFAULT', 'win_windows', winpath.get_windows())
-    config.set('DEFAULT', 'win_startup', winpath.get_startup())
-    config.set('DEFAULT', 'win_recent', winpath.get_recent())
 
 def get(section, option, default=None):
 

--- a/hydra_base/util/windows.py
+++ b/hydra_base/util/windows.py
@@ -43,7 +43,7 @@ def check_ret_err(result, func, args):
 
 def win_get_common_documents():
     # If the more recent KPF system is available, use this...
-    if Win_SHGetKnownFolderPath := getattr(windll.shell32, "SHGetKnownFolderPath"):
+    if Win_SHGetKnownFolderPath := getattr(windll.shell32, "SHGetKnownFolderPath", None):
         Win_SHGetKnownFolderPath.argtypes = [
             ctypes.POINTER(GUID),
             wintypes.DWORD,

--- a/hydra_base/util/windows.py
+++ b/hydra_base/util/windows.py
@@ -1,0 +1,82 @@
+import ctypes
+import sys
+import uuid
+
+
+try:
+    from ctypes import (
+        windll,
+        wintypes
+    )
+except ImportError as exc:
+    raise Warning(f"Attempt to use Windows utils on {sys.platform} platform") from exc
+
+
+# Pre-Vista CSIDL
+CSIDL_COMMON_DOCUMENTS = 46
+# Vista onwards Known Folder ID
+# From https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid
+KFP_PUBLIC_DOCUMENTS = uuid.UUID("{ED4824AF-DCE4-45A8-81E2-FC7965083634}")
+
+
+class GUID(ctypes.Structure):
+    # windsdk/guiddef.h
+    _fields_ = [
+        ("Data1", wintypes.DWORD),
+        ("Data2", wintypes.WORD),
+        ("Data3", wintypes.WORD),
+        ("Data4", wintypes.BYTE*8)
+    ]
+
+    def __init__(self, _uuid):
+        ctypes.Structure.__init__(self)
+        self.Data1, self.Data2, self.Data3 = _uuid.fields[:3]
+        self.Data4[:] = _uuid.bytes[8:]
+
+
+def check_ret_err(result, func, args):
+    if result != 0:
+        raise OSerror("Unable to locate Common Documents")
+
+    return args
+
+
+def win_get_common_documents():
+    # If the more recent KPF system is available, use this...
+    if Win_SHGetKnownFolderPath := getattr(windll.shell32, "SHGetKnownFolderPath"):
+        Win_SHGetKnownFolderPath.argtypes = [
+            ctypes.POINTER(GUID),
+            wintypes.DWORD,
+            wintypes.HANDLE,
+            ctypes.POINTER(ctypes.c_wchar_p)
+        ]
+        Win_SHGetKnownFolderPath.errcheck = check_ret_err
+
+        kfp = GUID(KFP_PUBLIC_DOCUMENTS)
+        path_buf = ctypes.c_wchar_p()
+        Win_SHGetKnownFolderPath(ctypes.byref(kfp), 0, 0, ctypes.byref(path_buf))
+
+        return path_buf.value
+
+    # ...otherwise use legacy CSIDL
+    elif Win_SHGetFolderPathW := getattr(windll.shell32, "SHGetFolderPathW", None):
+        Win_SHGetFolderPathW.argtypes = [
+            wintypes.HWND,
+            ctypes.c_int,
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            wintypes.LPCWSTR
+        ]
+        Win_SHGetFolderPathW.errcheck = check_ret_err
+
+        path_buf = ctypes.create_unicode_buffer(wintypes.MAX_PATH)
+        Win_SHGetFolderPathW(0, CSIDL_COMMON_DOCUMENTS, 0, 0, path_buf)
+
+        return path_buf.value
+    else:
+        raise OSError("Unable to access Windows environment")
+
+
+if __name__ == "__main__":
+    cdp = win_get_common_documents()
+    print(cdp)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ try:
 except:
     pass
 
-import platform
 import sys
 import os
 
@@ -31,9 +30,6 @@ with open(os.path.join(os.path.dirname(__file__), "hydra_base", "__init__.py")) 
     for line in f:
         if line.startswith("__version__"):
             version = line.split("=")[1].strip().strip("\"'")
-
-if platform.system() == "Windows":  # only add winpath when platform is Windows so that setup.py is universal
-    install_requires.append("winpath")
 
 setup(
     name='hydra-base',

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -1,0 +1,32 @@
+import sys
+
+import pytest
+
+
+def test_safe_on_non_windows_platforms():
+    """
+      Verifies that a Warning is raised on non-Windows platforms
+      when attempting to import a Windows-only util and that
+      import succeeds on Windows
+    """
+    if sys.platform.startswith("win"):
+        from hydra_base.util.windows import win_get_common_documents
+    else:
+        with pytest.raises(Warning):
+            from hydra_base.util.windows import win_get_common_documents
+
+
+@pytest.mark.skipif(not sys.platform.startswith("win"), reason="Skipping Windows platform tests")
+class TestWindows:
+
+    def test_win_get_common_documents(self):
+        """
+          Do the Windows utils import correctly, find an appropriate
+          windll function, and successfully call this to identify
+          a path?
+        """
+        from hydra_base.util.windows import win_get_common_documents
+        common_doc_path = win_get_common_documents()
+        assert isinstance(str, common_doc_path)
+        assert len(common_doc_path) > 0
+


### PR DESCRIPTION
Replaces the `winpath` package with direct calls to the Windows shell via ctypes.  This takes one of two forms depending on the version of Windows
* The `SHGetKnownFolderPath` function where this is available, using a GUID to identify the "Common Documents" location
* The `SHGetFolderPathW` on pre-Vista platforms, using the CSIDL for "Common Documents"

A test and updates to config.py are added.