### PR TITLE
Change return type of attributes.add_resource_attributes

### DIFF
--- a/hydra_base/lib/objects.py
+++ b/hydra_base/lib/objects.py
@@ -49,7 +49,7 @@ class JSONObject(dict):
         Pass in a nested dictionary, a SQLAlchemy object or a JSON string.
     """
     def __init__(self, obj_dict={}, parent=None, extras={}, normalize=True):
-        
+
         if normalize:
             obj = self.normalise_input(obj_dict)
         else:
@@ -57,6 +57,12 @@ class JSONObject(dict):
 
         for k in obj:
             v = obj[k]
+
+            # Preserve tuples as keys of dictionaries
+            if isinstance(k, tuple):
+                self[k] = v
+                continue
+
             if k == "value_ref":
                 continue
 
@@ -146,6 +152,7 @@ class JSONObject(dict):
                     v = six.text_type(v)
 
                 self[six.text_type(k)] = v
+
 
         for k, v in extras.items():
             self[k] = v

--- a/tests/attributes/test_attributes.py
+++ b/tests/attributes/test_attributes.py
@@ -275,11 +275,12 @@ class TestResourceAttribute:
             existing_attr
         ]
 
-        num_added = client.add_resource_attributes(newattributes)
+        added_attrs = client.add_resource_attributes(newattributes)
 
         updated_network = client.get_network(network_with_data.id)
 
-        assert len(updated_network.attributes) == len(network_with_data.attributes) + len(num_added)
+        assert (network_with_data.id, new_attr.id) in added_attrs
+        assert len(updated_network.attributes) == len(network_with_data.attributes) + len(added_attrs)
 
         assert new_attr.id in [netattr.attr_id for netattr in updated_network.attributes]
 


### PR DESCRIPTION
Closes #268, return type of `lib.attributes.add_resource_attributes()` becomes a dict and test is updated.

Note a change to `JSONObject` to allow a tuple to act as the key of a dict.