### PR TITLE
Remove an individual project from the user cache on setting status to 'X'

### DIFF
--- a/hydra_base/db/model/project.py
+++ b/hydra_base/db/model/project.py
@@ -348,6 +348,16 @@ class Project(Base, Inspect, PermissionControlled):
 
         cls._build_user_cache_up_tree(uid, parent_project_ids, project_user_cache)
 
+
+    def remove_from_cache(self):
+        """Remove this project from the cache of all users who can see it"""
+        projectcache = cache.get(project_cache_key, {})
+        for uid, user_projects in projectcache.items():
+            for parent_id, child_projects in user_projects.items():
+                if self.id in child_projects:
+                    child_projects.remove(self.id)
+        cache.set(project_cache_key, projectcache)
+
     def get_attribute_data(self):
         attribute_data_rs = get_session().query(ResourceScenario).join(ResourceAttr).filter(
             ResourceAttr.project_id==self.id).all()

--- a/hydra_base/lib/project.py
+++ b/hydra_base/lib/project.py
@@ -485,11 +485,14 @@ def get_project_attribute_data(project_id, **kwargs):
 @required_perms('delete_project')
 def set_project_status(project_id, status, **kwargs):
     """
-        Set the status of a project to 'X'
+        Set the status of a project to 'X' or 'A'
     """
     user_id = kwargs.get('user_id')
     project = _get_project(project_id, user_id, check_write=True)
     project.status = status
+    if status.lower() == 'x':
+        #delete the project from the cache
+        project.remove_from_cache()
     db.DBSession.flush()
 
 @required_perms('edit_project', 'delete_project')

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -469,3 +469,19 @@ class TestProject:
         client.user_id = pytest.user_c.id
         with pytest.raises(hb.HydraError):
             client.get_project(proj.id)
+
+    def test_set_project_status_cache_invalidation(self, client, projectmaker):
+        proj = projectmaker.create()
+        project_id = proj.id
+
+        proj1 = client.get_project(project_id)
+        assert proj1.status == 'A'
+
+        client.set_project_status(project_id, 'X')
+
+        proj2 = client.get_project(project_id)
+        assert proj2.status == 'X'
+
+        #get projecs again to check the project is no longer present
+        projects = client.get_projects(pytest.root_user_id)
+        assert project_id not in [p.id for p in projects]


### PR DESCRIPTION

1: Add a new function to remove an individual project from the user cache.

2: WHen the status of a project is set to 'X' then remove it from the user cache