### PR TITLE
Hybrid attribute migration phase 1: schema + dual-write

### DIFF
--- a/hydra_base/db/alembic/versions/9b9f7d7a4f21_hybrid_attr_phase1.py
+++ b/hydra_base/db/alembic/versions/9b9f7d7a4f21_hybrid_attr_phase1.py
@@ -1,0 +1,68 @@
+"""hybrid_attr_phase1
+
+Revision ID: 9b9f7d7a4f21
+Revises: 580425ade2e4, 877adf863b33, cec2b77ad85e
+Create Date: 2026-07-01 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9b9f7d7a4f21'
+down_revision = ('580425ade2e4', '877adf863b33', 'cec2b77ad85e')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('tResourceAttr', sa.Column('attr_name', sa.String(length=200), nullable=True))
+    op.add_column('tResourceAttr', sa.Column('dimension_id', sa.Integer(), nullable=True))
+    op.create_foreign_key('fk_tresourceattr_dimension_id', 'tResourceAttr', 'tDimension', ['dimension_id'], ['id'])
+
+    op.add_column('tTypeAttr', sa.Column('attr_name', sa.String(length=200), nullable=True))
+    op.add_column('tTypeAttr', sa.Column('dimension_id', sa.Integer(), nullable=True))
+    op.create_foreign_key('fk_ttypeattr_dimension_id', 'tTypeAttr', 'tDimension', ['dimension_id'], ['id'])
+
+    op.execute(
+        """
+        UPDATE tResourceAttr
+        SET attr_name = (
+                SELECT name FROM tAttr WHERE tAttr.id = tResourceAttr.attr_id
+            ),
+            dimension_id = (
+                SELECT dimension_id FROM tAttr WHERE tAttr.id = tResourceAttr.attr_id
+            )
+        WHERE attr_id IS NOT NULL
+        """
+    )
+
+    op.execute(
+        """
+        UPDATE tTypeAttr
+        SET attr_name = (
+                SELECT name FROM tAttr WHERE tAttr.id = tTypeAttr.attr_id
+            ),
+            dimension_id = (
+                SELECT dimension_id FROM tAttr WHERE tAttr.id = tTypeAttr.attr_id
+            )
+        WHERE attr_id IS NOT NULL
+        """
+    )
+
+    op.alter_column('tResourceAttr', 'attr_id', existing_type=sa.Integer(), nullable=True)
+    op.alter_column('tTypeAttr', 'attr_id', existing_type=sa.Integer(), nullable=True)
+
+
+def downgrade():
+    op.alter_column('tTypeAttr', 'attr_id', existing_type=sa.Integer(), nullable=False)
+    op.alter_column('tResourceAttr', 'attr_id', existing_type=sa.Integer(), nullable=False)
+
+    op.drop_constraint('fk_ttypeattr_dimension_id', 'tTypeAttr', type_='foreignkey')
+    op.drop_column('tTypeAttr', 'dimension_id')
+    op.drop_column('tTypeAttr', 'attr_name')
+
+    op.drop_constraint('fk_tresourceattr_dimension_id', 'tResourceAttr', type_='foreignkey')
+    op.drop_column('tResourceAttr', 'dimension_id')
+    op.drop_column('tResourceAttr', 'attr_name')

--- a/hydra_base/db/model/network/link.py
+++ b/hydra_base/db/model/network/link.py
@@ -75,9 +75,11 @@ class Link(Base, Inspect, Resource):
     def link_description_setter(self):
         self.description = self.link_description
 
-    def add_attribute(self, attr_id, attr_is_var='N'):
+    def add_attribute(self, attr_id, attr_is_var='N', attr_name=None, dimension_id=None):
         res_attr = ResourceAttr()
         res_attr.attr_id = attr_id
+        res_attr.attr_name = attr_name
+        res_attr.dimension_id = dimension_id
         res_attr.attr_is_var = attr_is_var
         res_attr.ref_key = self.ref_key
         res_attr.link_id  = self.id

--- a/hydra_base/db/model/network/network.py
+++ b/hydra_base/db/model/network/network.py
@@ -78,9 +78,11 @@ class Network(Base, Inspect, PermissionControlled, Resource):
     def get_name(self):
         return self.name
 
-    def add_attribute(self, attr_id, attr_is_var='N'):
+    def add_attribute(self, attr_id, attr_is_var='N', attr_name=None, dimension_id=None):
         res_attr = ResourceAttr()
         res_attr.attr_id = attr_id
+        res_attr.attr_name = attr_name
+        res_attr.dimension_id = dimension_id
         res_attr.attr_is_var = attr_is_var
         res_attr.ref_key = self.ref_key
         res_attr.network_id  = self.id

--- a/hydra_base/db/model/network/node.py
+++ b/hydra_base/db/model/network/node.py
@@ -71,9 +71,11 @@ class Node(Base, Inspect, Resource):
     def node_description_setter(self):
         self.description = self.node_description
 
-    def add_attribute(self, attr_id, attr_is_var='N'):
+    def add_attribute(self, attr_id, attr_is_var='N', attr_name=None, dimension_id=None):
         res_attr = ResourceAttr()
         res_attr.attr_id = attr_id
+        res_attr.attr_name = attr_name
+        res_attr.dimension_id = dimension_id
         res_attr.attr_is_var = attr_is_var
         res_attr.ref_key = self.ref_key
         res_attr.node_id  = self.id

--- a/hydra_base/db/model/network/resourceattr.py
+++ b/hydra_base/db/model/network/resourceattr.py
@@ -35,7 +35,9 @@ class ResourceAttr(Base, Inspect):
     )
 
     id = Column(Integer(), primary_key=True, nullable=False)
-    attr_id = Column(Integer(), ForeignKey('tAttr.id'), nullable=False)
+    attr_id = Column(Integer(), ForeignKey('tAttr.id'), nullable=True)
+    attr_name = Column(String(200), nullable=True)
+    dimension_id = Column(Integer(), ForeignKey('tDimension.id'), nullable=True)
     ref_key = Column(String(60), nullable=False, index=True)
     network_id = Column(Integer(), ForeignKey('tNetwork.id'), index=True, nullable=True)
     project_id = Column(Integer(), ForeignKey('tProject.id'), index=True, nullable=True)
@@ -46,6 +48,7 @@ class ResourceAttr(Base, Inspect):
     cr_date = Column(TIMESTAMP(), nullable=False, server_default=text(u'CURRENT_TIMESTAMP'))
 
     attr = relationship('Attr')
+    dimension = relationship('Dimension', foreign_keys=[dimension_id])
     project = relationship('Project',
                            backref=backref('attributes',
                                            uselist=True,

--- a/hydra_base/db/model/network/resourcegroup.py
+++ b/hydra_base/db/model/network/resourcegroup.py
@@ -69,9 +69,11 @@ class ResourceGroup(Base, Inspect, Resource):
     def group_description_setter(self):
         self.description = self.group_description
 
-    def add_attribute(self, attr_id, attr_is_var='N'):
+    def add_attribute(self, attr_id, attr_is_var='N', attr_name=None, dimension_id=None):
         res_attr = ResourceAttr()
         res_attr.attr_id = attr_id
+        res_attr.attr_name = attr_name
+        res_attr.dimension_id = dimension_id
         res_attr.attr_is_var = attr_is_var
         res_attr.ref_key = self.ref_key
         res_attr.group_id  = self.id

--- a/hydra_base/db/model/project.py
+++ b/hydra_base/db/model/project.py
@@ -366,9 +366,11 @@ class Project(Base, Inspect, PermissionControlled):
         self.attribute_data = attribute_data_rs
         return attribute_data_rs
 
-    def add_attribute(self, attr_id, attr_is_var='N'):
+    def add_attribute(self, attr_id, attr_is_var='N', attr_name=None, dimension_id=None):
         res_attr = ResourceAttr()
         res_attr.attr_id = attr_id
+        res_attr.attr_name = attr_name
+        res_attr.dimension_id = dimension_id
         res_attr.attr_is_var = attr_is_var
         res_attr.ref_key = self.ref_key
         res_attr.project_id  = self.id

--- a/hydra_base/db/model/template.py
+++ b/hydra_base/db/model/template.py
@@ -477,7 +477,9 @@ class TypeAttr(Base, Inspect):
 
     id = Column(Integer(), primary_key=True, nullable=False)
     parent_id = Column(Integer(), ForeignKey('tTypeAttr.id'))
-    attr_id = Column(Integer(), ForeignKey('tAttr.id'), nullable=False)
+    attr_id = Column(Integer(), ForeignKey('tAttr.id'), nullable=True)
+    attr_name = Column(String(200), nullable=True)
+    dimension_id = Column(Integer(), ForeignKey('tDimension.id'), nullable=True)
     type_id = Column(Integer(), ForeignKey('tTemplateType.id', ondelete='CASCADE'),
                      nullable=False)
     default_dataset_id = Column(Integer(), ForeignKey('tDataset.id'))
@@ -494,6 +496,7 @@ class TypeAttr(Base, Inspect):
     parent = relationship('TypeAttr', remote_side=[id], backref=backref("children", order_by=id))
 
     attr = relationship('Attr')
+    dimension = relationship('Dimension', foreign_keys=[dimension_id])
     #Don't use a cascade delete all here. Instead force the code to delete the typeattrs
     #manually, to avoid accidentally deleting them
     templatetype = relationship('TemplateType',

--- a/hydra_base/lib/attributes.py
+++ b/hydra_base/lib/attributes.py
@@ -922,6 +922,12 @@ def add_resource_attributes(resource_attributes, **kwargs):
 
     field_to_key = {v: k for k, v in key_to_field.items()}
 
+    attr_ids = [ra.attr_id for ra in resource_attributes if ra.get('attr_id') is not None]
+    attr_lookup = {}
+    if attr_ids:
+        attrs = db.DBSession.query(Attr).filter(Attr.id.in_(attr_ids)).all()
+        attr_lookup = {a.id: a for a in attrs}
+
     for ra in resource_attributes:
         if ra.get('is_var') is not None:
             ra['attr_is_var'] = ra['is_var']
@@ -953,6 +959,12 @@ def add_resource_attributes(resource_attributes, **kwargs):
             target_field = key_to_field.get(ra['ref_key'])
             if target_field:
                 ra[target_field] = ra['ref_id']
+
+        attr_id = ra.get('attr_id')
+        attr_i = attr_lookup.get(attr_id)
+        if attr_i is not None:
+            ra['attr_name'] = ra.get('attr_name', attr_i.name)
+            ra['dimension_id'] = ra.get('dimension_id', attr_i.dimension_id)
 
     ras_to_be_inserted = []
 
@@ -1057,7 +1069,12 @@ def add_resource_attribute(resource_type, resource_id, attr_id, is_var, error_on
 
     attr_is_var = 'Y' if is_var in (True, 'Y') else 'N'
 
-    new_ra = resource_i.add_attribute(attr_id, attr_is_var)
+    new_ra = resource_i.add_attribute(
+        attr_id,
+        attr_is_var,
+        attr_name=attr.name,
+        dimension_id=attr.dimension_id,
+    )
     db.DBSession.flush()
 
     return new_ra
@@ -1092,7 +1109,11 @@ def add_resource_attrs_from_type(type_id, resource_type, resource_id, **kwargs):
     new_resource_attrs = []
     for item in type_i.typeattrs:
         if attrs.get(item.attr_id) is None:
-            ra = resource_i.add_attribute(item.attr_id)
+            ra = resource_i.add_attribute(
+                item.attr_id,
+                attr_name=item.attr.name if item.attr is not None else getattr(item, 'attr_name', None),
+                dimension_id=item.attr.dimension_id if item.attr is not None else getattr(item, 'dimension_id', None),
+            )
             new_resource_attrs.append(ra)
 
     db.DBSession.flush()

--- a/hydra_base/lib/attributes.py
+++ b/hydra_base/lib/attributes.py
@@ -297,6 +297,10 @@ def _add_attribute(attr, user_id, flush=True, do_reassign=False):
         if flush is True:
             db.DBSession.flush()
 
+    # Return ORM object if not flushed (to get ID after batch flush)
+    # Return JSONObject if already flushed
+    if flush is False:
+        return attr_i
     return JSONObject(attr_i)
 
 def _reassign_scoped_attributes(attr_id, user_id):
@@ -625,8 +629,29 @@ def add_attributes(attrs, **kwargs):
     #add a new attribute.
     user_id = kwargs.get('user_id')
 
-    # All global attributes
-    global_attrs = db.DBSession.query(Attr).filter(and_(Attr.network_id == None, Attr.project_id == None)).all()
+    # Extract incoming attr keys to filter queries and avoid loading unnecessary rows
+    incoming_attr_keys = []
+    for a in attrs:
+        if a is not None:
+            incoming_attr_keys.append((a.name.lower(), a.dimension_id))
+
+    if not incoming_attr_keys:
+        return []
+
+    # Build OR conditions for filtering queries by (name, dimension_id) pairs
+    name_dim_filters = [
+        and_(func.lower(Attr.name) == name, Attr.dimension_id == dim)
+        for name, dim in incoming_attr_keys
+    ]
+
+    # All global attributes matching incoming names/dimensions
+    global_attrs = db.DBSession.query(Attr).filter(
+        and_(
+            Attr.network_id == None,
+            Attr.project_id == None,
+            or_(*name_dim_filters)
+        )
+    ).all()
 
     #project-scoped attributes
     project_attrs = []
@@ -658,21 +683,22 @@ def add_attributes(attrs, **kwargs):
     #go top down, saving the attributes, and overwriting the duplicates as we
     #go down the tree.
     project_attr_dict = {}
-    seen = []
-    for project_id in project_ids + network_project_ids:
-        #  avoid duplicates. Can't use a set here because order is important
-        if project_id in seen:
-            continue
-        else:
-            seen.append(project_id)
-        project_attrs = db.DBSession.query(Attr).filter(Attr.project_id == project_id).all()
+    if project_ids + network_project_ids:
+        # Query for project attrs matching incoming keys in a single query
+        project_attrs = db.DBSession.query(Attr).filter(
+            Attr.project_id.in_(project_ids + network_project_ids),
+            or_(*name_dim_filters)
+        ).all()
         for project_attr in project_attrs:
-            project_attr_dict[(project_attr.name, project_attr.dimension)] = project_attr
+            project_attr_dict[(project_attr.name, project_attr.dimension_id)] = project_attr
 
     #network scoped attributes
     network_attrs = []
     if len(network_ids) > 0:
-        network_attrs = db.DBSession.query(Attr).filter(Attr.network_id.in_(network_ids)).all()
+        network_attrs = db.DBSession.query(Attr).filter(
+            Attr.network_id.in_(network_ids),
+            or_(*name_dim_filters)
+        ).all()
 
     all_attrs = global_attrs + list(project_attr_dict.values()) + network_attrs
 
@@ -694,16 +720,22 @@ def add_attributes(attrs, **kwargs):
             else:
                 attrs_to_add.append(JSONObject(potential_new_attr))
 
-    new_attrs = []
+    # Batch insert: collect ORM objects without flushing individually
+    orm_attrs = []
     for attr in attrs_to_add:
-        new_attr_i = _add_attribute(attr, flush=True, user_id=user_id)
-        new_attrs.append(new_attr_i)
+        new_attr_i = _add_attribute(attr, flush=False, user_id=user_id)
+        orm_attrs.append(new_attr_i)
 
+    # Single flush for all new attributes instead of per-attribute flushes
     db.DBSession.flush()
 
+    # Convert ORM objects to JSONObjects AFTER flush so they have IDs assigned
+    new_attrs = [JSONObject(a) for a in orm_attrs]
+
+    # Combine with existing attributes (which are already JSONObjects)
     new_attrs = new_attrs + existing_attrs
 
-    return [JSONObject(a) for a in new_attrs]
+    return new_attrs
 
 def get_attributes(network_id=None,
                    project_id=None,

--- a/hydra_base/lib/attributes.py
+++ b/hydra_base/lib/attributes.py
@@ -629,28 +629,18 @@ def add_attributes(attrs, **kwargs):
     #add a new attribute.
     user_id = kwargs.get('user_id')
 
-    # Extract incoming attr keys to filter queries and avoid loading unnecessary rows
-    incoming_attr_keys = []
-    for a in attrs:
-        if a is not None:
-            incoming_attr_keys.append((a.name.lower(), a.dimension_id))
+    # Deduplicate to unique lowercase names for an efficient IN filter.
+    # Exact (name, dimension_id) matching is done in Python via attr_dict below.
+    unique_lower_names = list({a.name.lower() for a in attrs if a is not None})
 
-    if not incoming_attr_keys:
+    if not unique_lower_names:
         return []
 
-    # Build OR conditions for filtering queries by (name, dimension_id) pairs
-    name_dim_filters = [
-        and_(func.lower(Attr.name) == name, Attr.dimension_id == dim)
-        for name, dim in incoming_attr_keys
-    ]
-
-    # All global attributes matching incoming names/dimensions
+    # All global attributes matching incoming names
     global_attrs = db.DBSession.query(Attr).filter(
-        and_(
-            Attr.network_id == None,
-            Attr.project_id == None,
-            or_(*name_dim_filters)
-        )
+        Attr.network_id == None,
+        Attr.project_id == None,
+        func.lower(Attr.name).in_(unique_lower_names)
     ).all()
 
     #project-scoped attributes
@@ -682,14 +672,17 @@ def add_attributes(attrs, **kwargs):
 
     #go top down, saving the attributes, and overwriting the duplicates as we
     #go down the tree.
+    all_project_ids = project_ids + network_project_ids
     project_attr_dict = {}
-    if project_ids + network_project_ids:
-        # Query for project attrs matching incoming keys in a single query
+    if all_project_ids:
         project_attrs = db.DBSession.query(Attr).filter(
-            Attr.project_id.in_(project_ids + network_project_ids),
-            or_(*name_dim_filters)
+            Attr.project_id.in_(all_project_ids),
+            func.lower(Attr.name).in_(unique_lower_names)
         ).all()
-        for project_attr in project_attrs:
+        # all_project_ids is ordered parent-first (root → leaf); sorting by that
+        # order ensures child entries overwrite parent entries for the same key.
+        project_id_order = {pid: i for i, pid in enumerate(all_project_ids)}
+        for project_attr in sorted(project_attrs, key=lambda a: project_id_order[a.project_id]):
             project_attr_dict[(project_attr.name, project_attr.dimension_id)] = project_attr
 
     #network scoped attributes
@@ -697,7 +690,7 @@ def add_attributes(attrs, **kwargs):
     if len(network_ids) > 0:
         network_attrs = db.DBSession.query(Attr).filter(
             Attr.network_id.in_(network_ids),
-            or_(*name_dim_filters)
+            func.lower(Attr.name).in_(unique_lower_names)
         ).all()
 
     all_attrs = global_attrs + list(project_attr_dict.values()) + network_attrs
@@ -720,9 +713,22 @@ def add_attributes(attrs, **kwargs):
             else:
                 attrs_to_add.append(JSONObject(potential_new_attr))
 
+    # Deduplicate to prevent IntegrityError when a caller submits two attrs
+    # with the same (name, dimension_id, scope) in one batch — the deferred
+    # flush means _check_can_add_attribute can't catch in-batch duplicates.
+    seen_new_keys = set()
+    deduped_attrs_to_add = []
+    for attr in attrs_to_add:
+        dedup_key = (attr.name.lower(), attr.dimension_id,
+                     getattr(attr, 'project_id', None),
+                     getattr(attr, 'network_id', None))
+        if dedup_key not in seen_new_keys:
+            seen_new_keys.add(dedup_key)
+            deduped_attrs_to_add.append(attr)
+
     # Batch insert: collect ORM objects without flushing individually
     orm_attrs = []
-    for attr in attrs_to_add:
+    for attr in deduped_attrs_to_add:
         new_attr_i = _add_attribute(attr, flush=False, user_id=user_id)
         orm_attrs.append(new_attr_i)
 

--- a/hydra_base/util/hdb.py
+++ b/hydra_base/util/hdb.py
@@ -19,7 +19,7 @@
 
 import os
 import json
-from ..db.model import Network, Scenario, Project, User, Role, Perm, RolePerm, RoleUser, ResourceAttr, ResourceType, Dimension, Unit
+from ..db.model import Network, Scenario, Project, User, Role, Perm, RolePerm, RoleUser, ResourceAttr, ResourceType, Dimension, Unit, Attr
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from .. import db
 import datetime
@@ -76,11 +76,22 @@ def add_resource_attributes(resource_i, attributes):
     if attributes is None:
         return {}
     resource_attrs = {}
+    attr_ids = [ra.attr_id for ra in attributes if getattr(ra, 'attr_id', None) is not None]
+    attr_lookup = {}
+    if attr_ids:
+        all_attrs = db.DBSession.query(Attr).filter(Attr.id.in_(attr_ids)).all()
+        attr_lookup = {a.id: a for a in all_attrs}
     #ra is for ResourceAttr
     for ra in attributes:
 
         if ra.id < 0:
-            ra_i = resource_i.add_attribute(ra.attr_id, ra.attr_is_var)
+            attr_i = attr_lookup.get(ra.attr_id)
+            ra_i = resource_i.add_attribute(
+                ra.attr_id,
+                ra.attr_is_var,
+                attr_name=attr_i.name if attr_i is not None else None,
+                dimension_id=attr_i.dimension_id if attr_i is not None else None,
+            )
             db.DBSession.add(ra_i)
         else:
             ra_i = db.DBSession.query(ResourceAttr).filter(ResourceAttr.id==ra.id).one()

--- a/tests/attributes/test_attributes.py
+++ b/tests/attributes/test_attributes.py
@@ -112,8 +112,6 @@ class TestAttribute:
         with pytest.raises(HydraError):
             client.update_attribute(new_attr_fail)
 
-
-
     def test_delete_attribute(self, client):
         test_attr = JSONObject({
             "name": 'Test Attribute 1',


### PR DESCRIPTION
## Summary
This PR implements phase 1 of the hybrid attribute migration in hydra-base while preserving resource_attr_id as the critical structural key.

## Changes
- Additive schema migration for tResourceAttr and tTypeAttr:
  - add attr_name
  - add dimension_id
  - backfill values from tAttr
  - make attr_id nullable for transition
- Model updates for new hybrid fields on ResourceAttr and TypeAttr
- Dual-write support in resource-attribute creation paths:
  - populate attr_name and dimension_id when attr_id is provided
  - keep legacy attr_id behavior intact

## Safety
- resource_attr_id is unchanged and remains the key used by scenarios/data links.
- Migration is additive and transitional; existing clients continue to work.

## Validation
- Syntax checks on touched files
- No reported diagnostics in modified files